### PR TITLE
refactor: 1407 refactor listings applicants db query

### DIFF
--- a/migrations/20240429140706_add-index-applicant-listing-id.js
+++ b/migrations/20240429140706_add-index-applicant-listing-id.js
@@ -1,0 +1,17 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  knex.schema.table('applicant', (t) => t.index('ListingId', 'idx_listingId'))
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  knex.schema.table('applicant', (t) =>
+    t.dropIndex('ListingId', 'idx_listingId')
+  )
+}

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -1,11 +1,4 @@
-import {
-  Applicant,
-  Invoice,
-  Listing,
-  ListingStatus, ApplicantStatus,
-  ParkingSpaceApplicationCategory,
-  parkingSpaceApplicationCategoryTranslation,
-} from 'onecore-types'
+import { Applicant, Listing, ApplicantStatus } from 'onecore-types'
 
 import knex from 'knex'
 import Config from '../../../common/config'
@@ -16,6 +9,8 @@ const db = knex({
 })
 
 function transformFromDbListing(row: any): Listing {
+  // TODO: Listing has some properties T | undefined.
+  // However, this function is returning null when the db returns null
   return {
     id: row.Id,
     rentalObjectCode: row.RentalObjectCode,
@@ -68,7 +63,7 @@ const createListing = async (listingData: Listing) => {
       Status: listingData.status,
       WaitingListType: listingData.waitingListType,
     })
-    .returning('*');
+    .returning('*')
 
   return transformFromDbListing(insertedRow[0])
 }
@@ -79,18 +74,20 @@ const createListing = async (listingData: Listing) => {
  * @param {string} rentalObjectCode - The rental object code of the listing (originally from xpand)
  * @returns {Promise<Listing>} - Promise that resolves to the existing listing if it exists.
  */
-const getListingByRentalObjectCode = async (rentalObjectCode: string): Promise<Listing | undefined> => {
+const getListingByRentalObjectCode = async (
+  rentalObjectCode: string
+): Promise<Listing | undefined> => {
   const listing = await db('Listing')
     .where({
-      RentalObjectCode: rentalObjectCode
+      RentalObjectCode: rentalObjectCode,
     })
-    .first();
+    .first()
 
-  if(listing == undefined){
+  if (listing == undefined) {
     return undefined
   }
   return transformFromDbListing(listing)
-};
+}
 
 /**
  * Checks if a listing already exists based on unique criteria.
@@ -98,18 +95,20 @@ const getListingByRentalObjectCode = async (rentalObjectCode: string): Promise<L
  * @param {number} listingId - The rental object code of the listing (originally from xpand)
  * @returns {Promise<Listing>} - Promise that resolves to the existing listing if it exists.
  */
-const getListingById = async (listingId: string): Promise<Listing | undefined> => {
+const getListingById = async (
+  listingId: string
+): Promise<Listing | undefined> => {
   const listing = await db('Listing')
     .where({
-      Id: listingId
+      Id: listingId,
     })
-    .first();
+    .first()
 
-  if(listing == undefined){
+  if (listing == undefined) {
     return undefined
   }
   return transformFromDbListing(listing)
-};
+}
 
 const createApplication = async (applicationData: Applicant) => {
   await db('applicant').insert({
@@ -119,80 +118,87 @@ const createApplication = async (applicationData: Applicant) => {
     ApplicationType: applicationData.applicationType,
     Status: applicationData.status,
     ListingId: applicationData.listingId,
-  });
+  })
 }
 
 /**
  * Updates the status of an existing applicant using the ApplicantStatus enum.
- * 
+ *
  * @param {number} applicantId - The ID of the applicant to update.
  * @param {ApplicantStatus} newStatus - The new status to set for the applicant.
  * @returns {Promise<boolean>} - Returns true if the update was successful, false otherwise.
  */
-const updateApplicantStatus = async (applicantId: number, status: ApplicantStatus) => {
+const updateApplicantStatus = async (
+  applicantId: number,
+  status: ApplicantStatus
+) => {
   try {
+    const updateCount = await db('applicant').where('Id', applicantId).update({
+      Status: status,
+    })
 
-    const updateCount = await db('applicant')
-      .where('Id', applicantId)
-      .update({
-        Status: status
-      });
-
-    return updateCount > 0;
+    return updateCount > 0
   } catch (error) {
-    console.error('Error updating applicant status:', error);
-    throw error;
+    console.error('Error updating applicant status:', error)
+    throw error
   }
 }
 
-//todo: use type and do type conversion to camelCase
 const getAllListingsWithApplicants = async () => {
-  const dbListings: Listing[] = await db('Listing').select('*');
-  let transformedListings: Listing[]  = []
+  const query = `
+    SELECT
+      l.*,
+      (
+        SELECT a.*
+        FROM applicant a
+        WHERE a.ListingId = l.Id
+        FOR JSON PATH
+      ) as applicants
+    FROM listing l
+  `
 
-  for (const listing of dbListings) {
-    let transformedListing = transformFromDbListing(listing)
-    transformedListings.push(transformedListing)
-  }
+  const parseApplicantsJson = (row: { applicants?: string }) => ({
+    ...row,
+    applicants: row.applicants ? JSON.parse(row.applicants) : [],
+  })
 
-  for (const listing of transformedListings) {
-    const dbApplicants = await db('Applicant')
-      .where('ListingId', listing.id)
-      .select('*');
+  const formatListing = (row: { applicants: Array<unknown> }) => ({
+    ...transformFromDbListing(row),
+    applicants: row.applicants.map(transformDbApplicant),
+  })
 
-    let transformedApplicants: Applicant[] = []
-    for(const applicant of dbApplicants){
-      transformedApplicants.push(transformDbApplicant(applicant))
-    }
-    listing.applicants = transformedApplicants
-  }
+  const result: Array<Listing> = await db
+    .raw(query)
+    .then((rows) => rows.map(parseApplicantsJson).map(formatListing))
 
-  return transformedListings;
-};
+  return result
+}
 
 const getApplicantsByContactCode = async (contactCode: string) => {
   const result = await db('Applicant')
     .where({ ContactCode: contactCode })
-    .select('*');
+    .select('*')
 
-    if (result == undefined){
-      return undefined
-    }
-    
-    // Map result array to Applicant objects
-    return result.map(transformDbApplicant);
+  if (result == undefined) {
+    return undefined
+  }
+
+  // Map result array to Applicant objects
+  return result.map(transformDbApplicant)
 }
 
-const getApplicantsByContactCodeAndRentalObjectCode = async (contactCode: string, rentalObjectCode: string) => {
+const getApplicantsByContactCodeAndRentalObjectCode = async (
+  contactCode: string,
+  rentalObjectCode: string
+) => {
   const result = await db('Applicant')
     .where({
       ContactCode: contactCode,
-      RentalObjectCode: rentalObjectCode
+      RentalObjectCode: rentalObjectCode,
     })
-    .first();
+    .first()
 
-  if(result == undefined)
-    return undefined
+  if (result == undefined) return undefined
 
   return transformDbApplicant(result)
 }
@@ -201,11 +207,11 @@ const applicationExists = async (contactCode: string, listingId: number) => {
   const result = await db('applicant')
     .where({
       ContactCode: contactCode,
-      ListingId: listingId
+      ListingId: listingId,
     })
-    .first();
-  return !!result; // Convert result to boolean: true if exists, false if not
-};
+    .first()
+  return !!result // Convert result to boolean: true if exists, false if not
+}
 
 export {
   createListing,
@@ -216,5 +222,6 @@ export {
   getApplicantsByContactCode,
   getApplicantsByContactCodeAndRentalObjectCode,
   applicationExists,
-  updateApplicantStatus
+  updateApplicantStatus,
 }
+

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -224,4 +224,3 @@ export {
   applicationExists,
   updateApplicantStatus,
 }
-

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -119,14 +119,14 @@ const getListingById = async (
     applicants: row.applicants ? JSON.parse(row.applicants) : [],
   })
 
-  const formatListing = (row: { applicants: Array<unknown> }): Listing => ({
+  const transformListing = (row: { applicants: Array<unknown> }): Listing => ({
     ...transformFromDbListing(row),
     applicants: row.applicants.map(transformDbApplicant),
   })
 
   if (!result) return undefined
 
-  return formatListing(parseApplicantsJson(result))
+  return transformListing(parseApplicantsJson(result))
 }
 
 const createApplication = async (applicationData: Applicant) => {
@@ -181,14 +181,14 @@ const getAllListingsWithApplicants = async () => {
     applicants: row.applicants ? JSON.parse(row.applicants) : [],
   })
 
-  const formatListing = (row: { applicants: Array<unknown> }) => ({
+  const transformListing = (row: { applicants: Array<unknown> }) => ({
     ...transformFromDbListing(row),
     applicants: row.applicants.map(transformDbApplicant),
   })
 
   const result: Array<Listing> = await db
     .raw(query)
-    .then((rows) => rows.map(parseApplicantsJson).map(formatListing))
+    .then((rows) => rows.map(parseApplicantsJson).map(transformListing))
 
   return result
 }

--- a/src/services/lease-service/tests/invoices.test.ts
+++ b/src/services/lease-service/tests/invoices.test.ts
@@ -157,9 +157,8 @@ describe('invoices-service', () => {
 
   describe('getUnpaidInvoicesByContactCode', () => {
     it('should return unpaid invoices for a contact', async () => {
-      const result = await invoiceAdapter.getUnpaidInvoicesByContactCode(
-        'contactKey'
-      )
+      const result =
+        await invoiceAdapter.getUnpaidInvoicesByContactCode('contactKey')
 
       expect(result).toBeDefined()
       expect(result).toHaveLength(3)

--- a/src/services/lease-service/tests/listing-adapter.test.ts
+++ b/src/services/lease-service/tests/listing-adapter.test.ts
@@ -1,0 +1,80 @@
+import { ApplicantStatus, ListingStatus } from 'onecore-types'
+import * as listingAdapter from '../adapters/listing-adapter'
+
+jest.mock('knex', () => () => ({
+  raw: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  then: jest.fn().mockImplementation((callback) =>
+    callback([
+      {
+        Id: 1,
+        RentalObjectCode: '705-025-03-0205/01',
+        Address: 'Testgatan 12',
+        MonthlyRent: 123,
+        DisctrictCaption: null,
+        DistrictCode: null,
+        BlockCaption: null,
+        BlockCode: null,
+        ObjectTypeCaption: null,
+        RentalObjectTypeCaption: null,
+        RentalObjectTypeCode: null,
+        PublishedFrom: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+        PublishedTo: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+        VacantFrom: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+        Status: ListingStatus.Active,
+        WaitingListType: null,
+        applicants: JSON.stringify([
+          {
+            Id: 1,
+            Name: 'Test Testsson',
+            ContactCode: '1234',
+            ApplicationDate: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+            ApplicationType: null,
+            Status: ApplicantStatus.Active,
+            ListingId: 1,
+          },
+        ]),
+      },
+      {
+        Id: 2,
+        RentalObjectCode: '705-025-03-0205/01',
+        Address: 'Testgatan 13',
+        MonthlyRent: 123,
+        DisctrictCaption: null,
+        DistrictCode: null,
+        BlockCaption: null,
+        BlockCode: null,
+        ObjectTypeCaption: null,
+        RentalObjectTypeCaption: null,
+        RentalObjectTypeCode: null,
+        PublishedFrom: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+        PublishedTo: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+        VacantFrom: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+        Status: ListingStatus.Active,
+        WaitingListType: null,
+        applicants: JSON.stringify([
+          {
+            Id: 3,
+            Name: 'Test Testsson',
+            ContactCode: '1234',
+            ApplicationDate: new Date('2023-02-28T00:00:00.000Z').toISOString(),
+            ApplicationType: null,
+            Status: ApplicantStatus.Active,
+            ListingId: 2,
+          },
+        ]),
+      },
+    ])
+  ),
+}))
+
+describe(listingAdapter.getAllListingsWithApplicants, () => {
+  it('returns a formatted list of listings and corresponding applicants', async () => {
+    const [fst, snd] = await listingAdapter.getAllListingsWithApplicants()
+    expect(fst.applicants).toHaveLength(1)
+    expect(fst.applicants?.[0]?.listingId).toBe(fst.id)
+
+    expect(snd.applicants).toHaveLength(1)
+    expect(snd.applicants?.[0]?.listingId).toBe(snd.id)
+  })
+})


### PR DESCRIPTION
- Adds an index to applicant.ListingId
- Use JSON sub query for listings and applicants
- Use JSON sub query for listing and applicants

I can't really decide whether to use a join or subquery for this.

I like the subquery approach because it's more straight forward and needs less post-processing to transform the result into the desired structure.

Then again people generally recommend join for performance reasons.

~~I decided to use join anyway because that's what the ticket said.. 😅~~
**EDIT**
Decided to use sub query instead after discussion with @driatic 
Motivation:
Readability, doesn't need as much post-processing and subquery will surely be adequate at this time.

Either way I guess we should add an index to applicant.LeasingId, so I did that.

**Note**
There is more diff in this PR than the relevant changes. This is because my linter formats the code in saved files.
I pretty sure my setup is correct (reads prettier from local environment). I suspect someone isnt correctly set up and formats files according to some other config.

Fixes [1407](https://dev.azure.com/mimeronline/ONECore/_boards/board/t/Uthyrning/Issues/?workitem=1407)

