### PR TITLE
fix: transform applicants applicationDate to date when querying as json

### DIFF
--- a/src/services/lease-service/priority-list-service.ts
+++ b/src/services/lease-service/priority-list-service.ts
@@ -4,6 +4,7 @@
  * Sorting applicants based on rental rules
  */
 
+import { logger } from 'onecore-utilities'
 import {
   Applicant,
   DetailedApplicant,
@@ -13,7 +14,6 @@ import {
   parkingSpaceApplicationCategoryTranslation,
   WaitingList,
 } from 'onecore-types'
-import { logger } from 'onecore-utilities'
 
 import { getWaitingList } from './adapters/xpand/xpand-soap-adapter'
 import { leaseTypes } from '../../constants/leaseTypes'

--- a/src/services/lease-service/routes/applicants.ts
+++ b/src/services/lease-service/routes/applicants.ts
@@ -75,9 +75,6 @@ export const routes = (router: KoaRouter) => {
     const { contactCode } = ctx.params // Extracting from URL parameters
     try {
       const applicants = await getApplicantsByContactCode(contactCode)
-      ctx.body = applicants
-      ctx.status = 200
-
       if (!applicants) {
         ctx.status = 404 // Not Found
         ctx.body = {


### PR DESCRIPTION
I couldn't find anything of the problem that the card describes: 
https://dev.azure.com/mimeronline/ONECore/_boards/board/t/Uthyrning/Issues/?workitem=1561

* Make sure applicants `applicationDate` is converted to date when fetching listing with applicants `FOR JSON PATH`
* Remove redundant 200 ok response declaration in /applicants/:contactCode/