### PR TITLE
Fix/1537 handle swagger spec path by base path

### DIFF
--- a/src/services/lease-service/routes/applicants.ts
+++ b/src/services/lease-service/routes/applicants.ts
@@ -320,8 +320,7 @@ export const routes = (router: KoaRouter) => {
    *               properties:
    *                 reason:
    *                   type: string
-   *                   example: No property rental rules applies to this
-   *                   property.
+   *                   example: No property rental rules applies to this property.
    *       403:
    *         description: Applicant is not eligible for the property based on property rental rules.
    *         content:
@@ -508,8 +507,7 @@ export const routes = (router: KoaRouter) => {
    *         required: true
    *         schema:
    *           type: string
-   *         description: The xpand district code of the residential area to
-   *         validate against.
+   *         description: The xpand district code of the residential area to validate against.
    *     responses:
    *       200:
    *         description: No residential area rental rules apply or applicant is eligible to apply for parking space.

--- a/src/services/swagger/index.ts
+++ b/src/services/swagger/index.ts
@@ -1,26 +1,13 @@
 import KoaRouter from '@koa/router'
 import swaggerJsdoc from 'swagger-jsdoc'
+import { swaggerSpec } from '../../swagger'
+
+const swaggerOptions = swaggerJsdoc(swaggerSpec)
 
 export const routes = (router: KoaRouter) => {
-  const options = {
-    definition: {
-      openapi: '3.0.0',
-      info: {
-        title: 'onecore-leasing',
-        version: '1.0.0',
-      },
-    },
-    apis: [
-      './src/services/health-service/*.ts',
-      './src/services/creditsafe/*.ts',
-      './src/services/lease-service/routes/*.ts',
-    ],
-  }
-
-  const swaggerSpec = swaggerJsdoc(options)
-
-  router.get('/swagger.json', async function (ctx) {
+  // Route to serve Swagger JSON
+  router.get('/swagger.json', async (ctx) => {
     ctx.set('Content-Type', 'application/json')
-    ctx.body = swaggerSpec
+    ctx.body = swaggerOptions
   })
 }

--- a/src/services/swagger/index.ts
+++ b/src/services/swagger/index.ts
@@ -5,7 +5,6 @@ import { swaggerSpec } from '../../swagger'
 const swaggerOptions = swaggerJsdoc(swaggerSpec)
 
 export const routes = (router: KoaRouter) => {
-  // Route to serve Swagger JSON
   router.get('/swagger.json', async (ctx) => {
     ctx.set('Content-Type', 'application/json')
     ctx.body = swaggerOptions

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -1,0 +1,16 @@
+const basePath = __dirname
+
+export const swaggerSpec = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'onecore-leasing',
+      version: '1.0.0',
+    },
+  },
+  apis: [
+    `${basePath}/services/health-service/*.{ts,js}`,
+    `${basePath}/services/creditsafe/*.{ts,js}`,
+    `${basePath}/services/lease-service/routes/*.{ts,js}`,
+  ],
+}


### PR DESCRIPTION
Fix to serve swagger spec from basepath of application. This fix resolves not being able to serve the spec when transpiled to js because `./src` does not exists in `./build`

`npm run dev` ->  ts local dev env 
`npm run build && node build/index.js` -> transpiled js (k8)
 

https://dev.azure.com/mimeronline/ONECore/_boards/board/t/Dev/Issues/?workitem=1537