### PR TITLE
MIM-133: Offer applicant

### DIFF
--- a/migrations/20240429140706_add-index-applicant-listing-id.js
+++ b/migrations/20240429140706_add-index-applicant-listing-id.js
@@ -3,7 +3,9 @@
  * @returns { Promise<void> }
  */
 exports.up = function (knex) {
-  return knex.schema.table('applicant', (t) => t.index('ListingId', 'idx_listingId'))
+  return knex.schema.table('applicant', (t) =>
+    t.index('ListingId', 'idx_listingId')
+  )
 }
 
 /**

--- a/migrations/20240928143018_create-offer-applicant.js
+++ b/migrations/20240928143018_create-offer-applicant.js
@@ -3,43 +3,57 @@
  * @returns { Promise<void> }
  */
 exports.up = function (knex) {
-  return knex.raw(`
-    -- TODO: Migrate existing data?
+  return knex.transaction(async (trx) => {
+    await trx.raw(`
+      ALTER TABLE offer
+      DROP COLUMN SelectionSnapshot;
+    `)
 
-    CREATE TABLE offer_applicant (
-      id int NOT NULL PRIMARY KEY IDENTITY(1,1),
-      listingId int NOT NULL,
-      offerId int NOT null,
-      applicantId int NOT NULL,
-      applicantStatus int NOT NULL,
-      applicantApplicationType text NOT NULL,
-      applicantQueuePoints int NOT NULL,
-      applicantAddress text NOT NULL,
-      applicantHasParkingSpace bit NOT NULL,
-      applicantHousingLeaseStatus int NOT NULL,
+    await trx.raw(`
+      -- TODO: Migrate existing data?
+      CREATE TABLE offer_applicant (
+        id int NOT NULL PRIMARY KEY IDENTITY(1,1),
+        listingId int NOT NULL,
+        offerId int NOT null,
+        applicantId int NOT NULL,
+        applicantStatus int NOT NULL,
+        applicantApplicationType text NOT NULL,
+        applicantQueuePoints int NOT NULL,
+        applicantAddress text NOT NULL,
+        applicantHasParkingSpace bit NOT NULL,
+        applicantHousingLeaseStatus int NOT NULL,
 
-      -- TODO: Does this need to be nullable?
-      applicantPriority int,
+        -- TODO: Does this need to be nullable?
+        applicantPriority int,
 
-      sortOrder int NOT NULL,
-      createdAt datetime NOT NULL DEFAULT GETUTCDATE(),
-      FOREIGN KEY (listingId) REFERENCES listing(id),
-      FOREIGN KEY (applicantId) REFERENCES applicant(id),
-      FOREIGN KEY (offerId) REFERENCES offer(id)
+        sortOrder int NOT NULL,
+        createdAt datetime NOT NULL DEFAULT GETUTCDATE(),
+        FOREIGN KEY (listingId) REFERENCES listing(id),
+        FOREIGN KEY (applicantId) REFERENCES applicant(id),
+        FOREIGN KEY (offerId) REFERENCES offer(id)
+      );
 
-    );
-
-    CREATE UNIQUE INDEX unique_offered_applicant_per_listing 
-    ON offer_applicant (listingId, applicantStatus)
-    WHERE applicantStatus = 6; -- ApplicantStatus.Offered
-  `)
+      CREATE UNIQUE INDEX unique_offered_applicant_per_listing 
+      ON offer_applicant (listingId, applicantStatus)
+      WHERE applicantStatus = 6; -- ApplicantStatus.Offered
+    `)
+  })
 }
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
 exports.down = function (knex) {
-  return knex.raw(`
-    DROP TABLE offer_applicant;
-  `)
+  return knex.transaction(async (trx) => {
+    await trx.raw(`
+      ALTER TABLE offer ADD SelectionSnapshot NVARCHAR(max);
+    `)
+
+    await trx.raw(`
+      UPDATE offer SET SelectionSnapshot = '[]';
+      ALTER TABLE offer ALTER COLUMN SelectionSnapshot NVARCHAR(max) NOT NULL;
+      DROP TABLE offer_applicant;
+    `)
+  })
 }

--- a/migrations/20240928143018_create-offer-applicant.js
+++ b/migrations/20240928143018_create-offer-applicant.js
@@ -10,7 +10,6 @@ exports.up = function (knex) {
     `)
 
     await trx.raw(`
-      -- TODO: Migrate existing data?
       CREATE TABLE offer_applicant (
         id int NOT NULL PRIMARY KEY IDENTITY(1,1),
         listingId int NOT NULL,
@@ -22,10 +21,7 @@ exports.up = function (knex) {
         applicantAddress text NOT NULL,
         applicantHasParkingSpace bit NOT NULL,
         applicantHousingLeaseStatus int NOT NULL,
-
-        -- TODO: Does this need to be nullable?
-        applicantPriority int,
-
+        applicantPriority int NOT NULL,
         sortOrder int NOT NULL,
         createdAt datetime NOT NULL DEFAULT GETUTCDATE(),
         FOREIGN KEY (listingId) REFERENCES listing(id),

--- a/migrations/20240928143018_create-offer-applicant.js
+++ b/migrations/20240928143018_create-offer-applicant.js
@@ -1,0 +1,40 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.raw(`
+    -- TODO: Migrate existing data?
+
+    CREATE TABLE offer_applicant (
+      id int NOT NULL PRIMARY KEY IDENTITY(1,1),
+      listingId int NOT NULL,
+      offerId int NOT null,
+      applicantId int NOT NULL,
+      applicantStatus int NOT NULL,
+      applicantApplicationType text NOT NULL,
+      applicantQueuePoints int NOT NULL,
+      applicantAddress text NOT NULL,
+      applicantHasParkingSpace bit NOT NULL,
+      applicantHousingLeaseStatus int NOT NULL,
+
+      -- TODO: Does this need to be nullable?
+      applicantPriority int,
+
+      sortOrder int NOT NULL,
+      createdAt datetime NOT NULL DEFAULT GETUTCDATE(),
+      FOREIGN KEY (listingId) REFERENCES listing(id),
+      FOREIGN KEY (applicantId) REFERENCES applicant(id),
+      FOREIGN KEY (offerId) REFERENCES offer(id)
+    );
+  `)
+}
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.raw(`
+    DROP TABLE offer_applicant;
+  `)
+}

--- a/migrations/20240928143018_create-offer-applicant.js
+++ b/migrations/20240928143018_create-offer-applicant.js
@@ -26,7 +26,12 @@ exports.up = function (knex) {
       FOREIGN KEY (listingId) REFERENCES listing(id),
       FOREIGN KEY (applicantId) REFERENCES applicant(id),
       FOREIGN KEY (offerId) REFERENCES offer(id)
+
     );
+
+    CREATE UNIQUE INDEX unique_offered_applicant_per_listing 
+    ON offer_applicant (listingId, applicantStatus)
+    WHERE applicantStatus = 6; -- ApplicantStatus.Offered
   `)
 }
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa2-swagger-ui": "^5.10.0",
         "mssql": "^11.0.1",
-        "onecore-types": "^1.27.0",
+        "onecore-types": "^1.28.0",
         "onecore-utilities": "^1.1.0",
         "personnummer": "^3.2.1",
         "pino": "^9.1.0",
@@ -7548,9 +7548,10 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.27.0.tgz",
-      "integrity": "sha512-/pberW9U9lYSMMC+o7jY6TijyIsXyGfSPXLrp7iQrDeJFY5GIXZP4ndoqDvvGgYuC+rlmgipadm0ouMRY0k1TQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.28.0.tgz",
+      "integrity": "sha512-qJrBz3FtdoiruJIOP7W839sEYNBFB7c1j1t+cY0fIdb1EnhbijqJ5z9NCASv8sAmErVw8nWXr8Wg5SvYccFFLw==",
+      "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa2-swagger-ui": "^5.10.0",
     "mssql": "^11.0.1",
-    "onecore-types": "^1.27.0",
+    "onecore-types": "^1.28.0",
     "onecore-utilities": "^1.1.0",
     "personnummer": "^3.2.1",
     "pino": "^9.1.0",

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -45,10 +45,17 @@ type OfferWithOfferApplicants = Offer & {
   selectedApplicants: Array<OfferApplicant>
 }
 
-type CreateOfferApplicantParams = Omit<
-  OfferApplicant,
-  'id' | 'createdAt' | 'offerId' | 'sortOrder'
->
+type CreateOfferApplicantParams = {
+  listingId: number
+  applicantId: number
+  status: ApplicantStatus
+  applicationType: 'Replace' | 'Additional'
+  queuePoints: number
+  address: string
+  hasParkingSpace: boolean
+  housingLeaseStatus: LeaseStatus
+  priority: number
+}
 
 type CreateOfferParams = {
   status: OfferStatus

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -6,7 +6,6 @@ import {
   OfferStatus,
   ApplicantStatus,
   LeaseStatus,
-  DetailedApplicant,
 } from 'onecore-types'
 import { logger } from 'onecore-utilities'
 import { Knex } from 'knex'
@@ -103,17 +102,15 @@ export async function create(
           Status,
           ExpiresAt,
           ListingId,
-          ApplicantId,
-          SelectionSnapshot
+          ApplicantId
         ) OUTPUT INSERTED.*
-        VALUES (?, ?, ?, ?, ?) 
+        VALUES (?, ?, ?, ?) 
         `,
         [
           offerParams.status,
           offerParams.expiresAt,
           offerParams.listingId,
           offerParams.applicantId,
-          '[]',
         ]
       )
 
@@ -164,7 +161,6 @@ export async function create(
         status: offer.Status,
         expiresAt: offer.ExpiresAt,
         sentAt: offer.CreatedAt,
-        // selectedApplicants: [],
         offeredApplicant: {
           id: applicant.Id,
           name: applicant.Name,
@@ -252,9 +248,6 @@ export async function getOffersForContact(
         status: ApplicantStatus,
         applicationType: ApplicantApplicationType ?? undefined,
       },
-      selectedApplicants: JSON.parse(
-        offer.SelectionSnapshot
-      ) as Array<DetailedApplicant>,
       rentalObjectCode: RentalObjectCode,
     }
   })
@@ -452,6 +445,7 @@ export async function updateOfferApplicant(
 
     return { ok: true, data: null }
   } catch (err) {
+    console.log(err)
     logger.error(err, 'Error updating offer applicant')
     return { ok: false, err: 'unknown' }
   }

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -49,7 +49,14 @@ export type OfferApplicant = {
   createdAt: Date
 }
 
-type CreateOfferApplicantParams = Omit<DbOfferApplicant, 'id' | 'createdAt'>
+type OfferWithOfferApplicants = Omit<Offer, 'selectedApplicants'> & {
+  selectedApplicants: Array<OfferApplicant>
+}
+
+type CreateOfferApplicantParams = Omit<
+  DbOfferApplicant,
+  'id' | 'createdAt' | 'offerId' | 'sortOrder'
+>
 
 type CreateOfferParams = {
   status: OfferStatus
@@ -57,10 +64,6 @@ type CreateOfferParams = {
   listingId: number
   applicantId: number
   selectedApplicants: Array<CreateOfferApplicantParams>
-}
-
-type OfferWithOfferApplicants = Omit<Offer, 'selectedApplicants'> & {
-  selectedApplicants: Array<OfferApplicant>
 }
 
 // TODO: Should this function construct the offer applicants partly based on
@@ -113,19 +116,21 @@ export async function create(
         ]
       )
 
-      const offerApplicantsValues = selectedApplicants.map((offerApplicant) => [
-        offer.Id,
-        params.listingId,
-        offerApplicant.applicantId,
-        offerApplicant.applicantStatus,
-        offerApplicant.applicantApplicationType,
-        offerApplicant.applicantQueuePoints,
-        offerApplicant.applicantAddress,
-        offerApplicant.applicantHasParkingSpace,
-        offerApplicant.applicantHousingLeaseStatus,
-        offerApplicant.applicantPriority,
-        offerApplicant.sortOrder,
-      ])
+      const offerApplicantsValues = selectedApplicants.map(
+        (offerApplicant, i) => [
+          offer.Id,
+          params.listingId,
+          offerApplicant.applicantId,
+          offerApplicant.applicantStatus,
+          offerApplicant.applicantApplicationType,
+          offerApplicant.applicantQueuePoints,
+          offerApplicant.applicantAddress,
+          offerApplicant.applicantHasParkingSpace,
+          offerApplicant.applicantHousingLeaseStatus,
+          offerApplicant.applicantPriority,
+          i + 1,
+        ]
+      )
 
       const placeholders = selectedApplicants
         .map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -65,8 +65,6 @@ type CreateOfferParams = {
   selectedApplicants: Array<CreateOfferApplicantParams>
 }
 
-// TODO: Should this function construct the offer applicants partly based on
-// the current state of the applicant in the db?
 export async function create(
   db: Knex,
   params: CreateOfferParams

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -66,7 +66,9 @@ type NewOffer = Omit<Offer, 'selectedApplicants'> & {
 export async function create(
   db: Knex,
   params: CreateOfferParams
-): Promise<AdapterResult<NewOffer, 'no-applicant' | 'unknown'>> {
+): Promise<
+  AdapterResult<NewOffer, 'no-applicant' | 'no-offer-applicants' | 'unknown'>
+> {
   try {
     const applicant = await db<DbApplicant>('applicant')
       .select('*')
@@ -81,10 +83,9 @@ export async function create(
       return { ok: false, err: 'no-applicant' }
     }
 
-    //todo: implement
-    // if(!params.offerApplicants.length){
-    //   return { ok: false, err: 'no-applicants' }
-    // }
+    if (!params.offerApplicants.length) {
+      return { ok: false, err: 'no-offer-applicants' }
+    }
 
     const offer = await db.transaction(async (trx) => {
       const { offerApplicants, ...offerParams } = params

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -365,7 +365,7 @@ export async function updateOfferStatus(
 export async function getOffersByListingId(
   listingId: number,
   dbConnection: Knex = db
-): Promise<AdapterResult<Array<Offer>, 'unknown'>> {
+): Promise<AdapterResult<Array<NewOffer>, 'unknown'>> {
   try {
     const rows = await dbConnection.raw<Array<any>>(`
       SELECT 
@@ -389,8 +389,6 @@ export async function getOffersByListingId(
         FOR JSON PATH
       ) as selectionSnapshot
       FROM offer
-      INNER JOIN applicant ON (offer.ApplicantId = applicant.Id)
-      INNER JOIN offer_applicant ON (offer_applicant.offerId = offer.Id)
       WHERE offer.ListingId = ${listingId}
     `)
 

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -514,7 +514,7 @@ const transformOfferWithOfferApplicantsQueryResult = (
   result: OffersWithOfferApplicantsQueryResult
 ): OfferWithOfferApplicants => {
   const offeredApplicant = JSON.parse(result.offeredApplicant) as DbApplicant
-  const offerApplicants = JSON.parse(result.offerApplicants) as Array<
+  const offerApplicants = (JSON.parse(result.offerApplicants) ?? []) as Array<
     DbOfferApplicant & {
       applicantName: string
       applicantApplicationDate: string

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -428,11 +428,11 @@ type NewDbOffer = DbOffer & {
 }
 
 export async function getOffersByListingId(
-  listingId: number,
-  dbConnection: Knex = db
+  db: Knex,
+  listingId: number
 ): Promise<AdapterResult<Array<NewOffer>, 'unknown'>> {
   try {
-    const rows = await dbConnection.raw<Array<NewDbOffer>>(`
+    const rows = await db.raw<Array<NewDbOffer>>(`
       SELECT 
       offer.Id,
       offer.SentAt,

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -108,28 +108,26 @@ export async function create(
         ]
       )
 
-      //todo: no offeredApplicants should not be allowed
-      if (params.offerApplicants.length) {
-        const offerApplicantsValues = offerApplicants.map((offerApplicant) => [
-          offer.Id,
-          params.listingId,
-          offerApplicant.applicantId,
-          offerApplicant.applicantStatus,
-          offerApplicant.applicantApplicationType,
-          offerApplicant.applicantQueuePoints,
-          offerApplicant.applicantAddress,
-          offerApplicant.applicantHasParkingSpace,
-          offerApplicant.applicantHousingLeaseStatus,
-          offerApplicant.applicantPriority,
-          offerApplicant.sortOrder,
-        ])
+      const offerApplicantsValues = offerApplicants.map((offerApplicant) => [
+        offer.Id,
+        params.listingId,
+        offerApplicant.applicantId,
+        offerApplicant.applicantStatus,
+        offerApplicant.applicantApplicationType,
+        offerApplicant.applicantQueuePoints,
+        offerApplicant.applicantAddress,
+        offerApplicant.applicantHasParkingSpace,
+        offerApplicant.applicantHousingLeaseStatus,
+        offerApplicant.applicantPriority,
+        offerApplicant.sortOrder,
+      ])
 
-        const placeholders = offerApplicants
-          .map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
-          .join(', ')
+      const placeholders = offerApplicants
+        .map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .join(', ')
 
-        await trx.raw(
-          `INSERT INTO offer_applicant (
+      await trx.raw(
+        `INSERT INTO offer_applicant (
           offerId,
           listingId,
           applicantId,
@@ -143,9 +141,8 @@ export async function create(
           sortOrder
         ) OUTPUT INSERTED.*
         VALUES ${placeholders}`,
-          offerApplicantsValues.flat()
-        )
-      }
+        offerApplicantsValues.flat()
+      )
 
       return offer
     })

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -54,7 +54,7 @@ type OfferWithOfferApplicants = Omit<Offer, 'selectedApplicants'> & {
 }
 
 type CreateOfferApplicantParams = Omit<
-  DbOfferApplicant,
+  OfferApplicant,
   'id' | 'createdAt' | 'offerId' | 'sortOrder'
 >
 
@@ -121,13 +121,13 @@ export async function create(
           offer.Id,
           params.listingId,
           offerApplicant.applicantId,
-          offerApplicant.applicantStatus,
-          offerApplicant.applicantApplicationType,
-          offerApplicant.applicantQueuePoints,
-          offerApplicant.applicantAddress,
-          offerApplicant.applicantHasParkingSpace,
-          offerApplicant.applicantHousingLeaseStatus,
-          offerApplicant.applicantPriority,
+          offerApplicant.status,
+          offerApplicant.applicationType,
+          offerApplicant.queuePoints,
+          offerApplicant.address,
+          offerApplicant.hasParkingSpace,
+          offerApplicant.housingLeaseStatus,
+          offerApplicant.priority,
           i + 1,
         ]
       )

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -69,7 +69,10 @@ export async function create(
   db: Knex,
   params: CreateOfferParams
 ): Promise<
-  AdapterResult<Offer, 'no-applicant' | 'no-offer-applicants' | 'unknown'>
+  AdapterResult<
+    Omit<Offer, 'selectedApplicants'>,
+    'no-applicant' | 'no-offer-applicants' | 'unknown'
+  >
 > {
   try {
     const applicant = await db<DbApplicant>('applicant')
@@ -157,7 +160,7 @@ export async function create(
         status: offer.Status,
         expiresAt: offer.ExpiresAt,
         sentAt: offer.CreatedAt,
-        selectedApplicants: [],
+        // selectedApplicants: [],
         offeredApplicant: {
           id: applicant.Id,
           name: applicant.Name,

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -88,7 +88,6 @@ export async function create(
 
     const offer = await db.transaction(async (trx) => {
       const { offerApplicants, ...offerParams } = params
-      console.log(params)
       const [offer] = await trx.raw<Array<DbOffer>>(
         `INSERT INTO offer (
           Status,
@@ -365,7 +364,7 @@ export async function getOfferByOfferId(
       },
     }
   } catch (error) {
-    logger.error(error, 'Error getting waiting list using Xpand SOAP API')
+    logger.error(error, 'Error getting offer by offer id')
     return { ok: false, err: 'unknown' }
   }
 }

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -63,6 +63,8 @@ type NewOffer = Omit<Offer, 'selectedApplicants'> & {
   selectedApplicants: Array<OfferApplicant>
 }
 
+// TODO: Should this function construct the offer applicants partly based on
+// the current state of the applicant in the db?
 export async function create(
   db: Knex,
   params: CreateOfferParams
@@ -149,7 +151,6 @@ export async function create(
 
     return { ok: true, data: transformToOfferFromDbOffer(offer, applicant) }
   } catch (err) {
-    console.log(err)
     logger.error(err, 'Error creating offer')
     return { ok: false, err: 'unknown' }
   }

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -5,7 +5,8 @@ import {
   DetailedOffer,
   OfferStatus,
   ApplicantStatus,
-  LeaseStatus,
+  OfferWithOfferApplicants,
+  CreateOfferParams,
 } from 'onecore-types'
 import { logger } from 'onecore-utilities'
 import { Knex } from 'knex'
@@ -20,50 +21,6 @@ import {
 } from './types'
 
 import * as dbUtils from './utils'
-
-export type OfferApplicant = {
-  id: number
-  listingId: number
-  offerId: number
-  applicantId: number
-  status: ApplicantStatus
-  applicationType: 'Replace' | 'Additional'
-  queuePoints: number
-  address: string
-  hasParkingSpace: boolean
-  housingLeaseStatus: LeaseStatus
-  priority: number
-  sortOrder: number
-  createdAt: Date
-
-  // Below properties comes from applicant table
-  applicationDate: Date
-  name: string
-}
-
-type OfferWithOfferApplicants = Offer & {
-  selectedApplicants: Array<OfferApplicant>
-}
-
-type CreateOfferApplicantParams = {
-  listingId: number
-  applicantId: number
-  status: ApplicantStatus
-  applicationType: 'Replace' | 'Additional'
-  queuePoints: number
-  address: string
-  hasParkingSpace: boolean
-  housingLeaseStatus: LeaseStatus
-  priority: number
-}
-
-type CreateOfferParams = {
-  status: OfferStatus
-  expiresAt: Date
-  listingId: number
-  applicantId: number
-  selectedApplicants: Array<CreateOfferApplicantParams>
-}
 
 export async function create(
   db: Knex,

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -69,10 +69,7 @@ export async function create(
   db: Knex,
   params: CreateOfferParams
 ): Promise<
-  AdapterResult<
-    Omit<Offer, 'selectedApplicants'>,
-    'no-applicant' | 'no-offer-applicants' | 'unknown'
-  >
+  AdapterResult<Offer, 'no-applicant' | 'no-offer-applicants' | 'unknown'>
 > {
   try {
     const applicant = await db<DbApplicant>('applicant')

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -32,6 +32,7 @@ export type DbOfferApplicant = {
   createdAt: Date
 }
 
+// TODO: Maybe exposed id should be applicantId to avoid confusion.
 export type OfferApplicant = {
   id: number
   listingId: number
@@ -116,21 +117,19 @@ export async function create(
         ]
       )
 
-      const offerApplicantsValues = selectedApplicants.map(
-        (offerApplicant, i) => [
-          offer.Id,
-          params.listingId,
-          offerApplicant.applicantId,
-          offerApplicant.status,
-          offerApplicant.applicationType,
-          offerApplicant.queuePoints,
-          offerApplicant.address,
-          offerApplicant.hasParkingSpace,
-          offerApplicant.housingLeaseStatus,
-          offerApplicant.priority,
-          i + 1,
-        ]
-      )
+      const offerApplicantsValues = selectedApplicants.map((a, i) => [
+        offer.Id,
+        params.listingId,
+        a.applicantId,
+        a.status,
+        a.applicationType,
+        a.queuePoints,
+        a.address,
+        a.hasParkingSpace,
+        a.housingLeaseStatus,
+        a.priority,
+        i + 1,
+      ])
 
       const placeholders = selectedApplicants
         .map(() => `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -413,10 +413,16 @@ export async function getOffersByListingId(
     `)
 
     const mappedRows = rows
-      .map((row) => ({
-        ...row,
-        offeredApplicant: JSON.parse(row.offeredApplicant as any),
-      }))
+      .map((row) => {
+        const offeredApplicant = JSON.parse(row.offeredApplicant as any)
+        return {
+          ...row,
+          offeredApplicant: {
+            ...offeredApplicant,
+            applicationDate: new Date(offeredApplicant.ApplicationDate),
+          },
+        }
+      })
       .map((row) => transformToOfferFromDbOffer(row, row.offeredApplicant))
 
     return {

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -420,9 +420,10 @@ export async function getOffersWithOfferApplicantsByListingId(
         (
           SELECT 
             oa.*,
-            a.ApplicationDate AS applicantApplicationDate,
-            a.Name AS applicantName
+            app.ApplicationDate AS applicantApplicationDate,
+            app.Name AS applicantName
           FROM offer_applicant oa
+          INNER JOIN applicant app ON oa.applicantId = app.Id
           WHERE oa.offerId = o.Id
           ORDER BY oa.sortOrder ASC
           FOR JSON PATH

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -21,7 +21,6 @@ import {
 
 import * as dbUtils from './utils'
 
-// TODO: Maybe exposed id should be applicantId to avoid confusion.
 export type OfferApplicant = {
   id: number
   listingId: number
@@ -33,7 +32,7 @@ export type OfferApplicant = {
   address: string
   hasParkingSpace: boolean
   housingLeaseStatus: LeaseStatus
-  priority: number | null
+  priority: number
   sortOrder: number
   createdAt: Date
 

--- a/src/services/lease-service/adapters/offer-adapter.ts
+++ b/src/services/lease-service/adapters/offer-adapter.ts
@@ -450,7 +450,7 @@ type GetOffersByListingIdQueryResult = DbOffer & {
   offeredApplicant: DbApplicant
 }
 
-export async function getOffersByListingId(
+export async function getOffersWithOfferApplicantsByListingId(
   db: Knex,
   listingId: number
 ): Promise<AdapterResult<Array<NewOffer>, 'unknown'>> {

--- a/src/services/lease-service/adapters/types.ts
+++ b/src/services/lease-service/adapters/types.ts
@@ -27,7 +27,7 @@ export type DbOfferApplicant = {
   applicantAddress: string
   applicantHasParkingSpace: boolean
   applicantHousingLeaseStatus: LeaseStatus
-  applicantPriority: number | null
+  applicantPriority: number
   sortOrder: number
   createdAt: Date
 }

--- a/src/services/lease-service/adapters/types.ts
+++ b/src/services/lease-service/adapters/types.ts
@@ -1,4 +1,9 @@
-import { ApplicantStatus, ListingStatus, OfferStatus } from 'onecore-types'
+import {
+  ApplicantStatus,
+  LeaseStatus,
+  ListingStatus,
+  OfferStatus,
+} from 'onecore-types'
 
 export type DbOffer = {
   Id: number
@@ -9,6 +14,22 @@ export type DbOffer = {
   ListingId: number
   ApplicantId: number
   CreatedAt: Date
+}
+
+export type DbOfferApplicant = {
+  id: number
+  listingId: number
+  offerId: number
+  applicantId: number
+  applicantStatus: ApplicantStatus
+  applicantApplicationType: 'Replace' | 'Additional'
+  applicantQueuePoints: number
+  applicantAddress: string
+  applicantHasParkingSpace: boolean
+  applicantHousingLeaseStatus: LeaseStatus
+  applicantPriority: number | null
+  sortOrder: number
+  createdAt: Date
 }
 
 export type DbDetailedOffer = {

--- a/src/services/lease-service/adapters/types.ts
+++ b/src/services/lease-service/adapters/types.ts
@@ -5,7 +5,6 @@ export type DbOffer = {
   SentAt: Date | null
   ExpiresAt: Date
   AnsweredAt: Date | null
-  SelectionSnapshot: string
   Status: OfferStatus
   ListingId: number
   ApplicantId: number

--- a/src/services/lease-service/offer-service.ts
+++ b/src/services/lease-service/offer-service.ts
@@ -74,7 +74,7 @@ export const denyOffer = async (params: {
     await db.transaction(async (trx) => {
       await updateApplicant(
         params.applicantId,
-        ApplicantStatus.WithdrawnByUser,
+        ApplicantStatus.OfferDeclined,
         trx
       )
       await updateOffer(params.offerId, OfferStatus.Declined, trx)

--- a/src/services/lease-service/offer-service.ts
+++ b/src/services/lease-service/offer-service.ts
@@ -24,12 +24,12 @@ export const acceptOffer = async (params: {
     await db.transaction(async (trx) => {
       await updateListing(params.listingId, trx)
       await updateApplicant(
+        trx,
         params.applicantId,
-        ApplicantStatus.OfferAccepted,
-        trx
+        ApplicantStatus.OfferAccepted
       )
-      await updateOffer(params.offerId, OfferStatus.Accepted, trx)
-      await updateOfferApplicants(
+      await updateOffer(trx, params.offerId, OfferStatus.Accepted)
+      await updateOfferApplicant(
         trx,
         params.offerId,
         params.listingId,
@@ -73,12 +73,12 @@ export const denyOffer = async (params: {
   try {
     await db.transaction(async (trx) => {
       await updateApplicant(
+        trx,
         params.applicantId,
-        ApplicantStatus.OfferDeclined,
-        trx
+        ApplicantStatus.OfferDeclined
       )
-      await updateOffer(params.offerId, OfferStatus.Declined, trx)
-      await updateOfferApplicants(
+      await updateOffer(trx, params.offerId, OfferStatus.Declined)
+      await updateOfferApplicant(
         trx,
         params.offerId,
         params.listingId,
@@ -118,9 +118,9 @@ const updateListing = async (listingId: number, trx: Knex) => {
 }
 
 const updateApplicant = async (
+  trx: Knex,
   applicantId: number,
-  applicantStatus: ApplicantStatus,
-  trx: Knex
+  applicantStatus: ApplicantStatus
 ) => {
   const updateApplicant = await listingAdapter.updateApplicantStatus(
     applicantId,
@@ -134,9 +134,9 @@ const updateApplicant = async (
 }
 
 const updateOffer = async (
+  trx: Knex,
   offerId: number,
-  offerStatus: OfferStatus,
-  trx: Knex
+  offerStatus: OfferStatus
 ) => {
   const updateOffer = await offerAdapter.updateOfferStatus(
     {
@@ -150,7 +150,7 @@ const updateOffer = async (
   }
 }
 
-const updateOfferApplicants = async (
+const updateOfferApplicant = async (
   trx: Knex,
   offerId: number,
   listingId: number,

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -124,7 +124,7 @@ export const routes = (router: KoaRouter) => {
           ctx.status = 201
           ctx.body = { content: offer.data, ...metadata }
           logger.info(
-            `offer # ${existingOffers.data.length + 1} created for listing ${offer.data.listingId}`
+            `offer # ${existingOffers.data.length + 1} created for listing ${ctx.request.body.listingId}`
           )
         }
 

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -103,7 +103,7 @@ export const routes = (router: KoaRouter) => {
             ctx.body = { error: 'Internal server error', ...metadata }
             return
           }
-          ctx.status = 500
+          ctx.status = 201
           ctx.body = { content: offer.data, ...metadata }
           return
         }

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -98,12 +98,14 @@ export const routes = (router: KoaRouter) => {
         //create initial offers if no previous offers exist
         if (!existingOffers.data.length) {
           const offer = await offerAdapter.create(db, requestBody)
-          if (offer.ok) {
-            ctx.status = 201
-            ctx.body = { content: offer.data, ...metadata }
+          if (!offer.ok) {
+            ctx.status = 500
+            ctx.body = { error: 'Internal server error', ...metadata }
             return
           }
-          //todo: add error handling
+          ctx.status = 500
+          ctx.body = { content: offer.data, ...metadata }
+          return
         }
 
         //check if any of the existing offers are still active

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -80,6 +80,7 @@ export const routes = (router: KoaRouter) => {
       const metadata = generateRouteMetadata(ctx)
       try {
         const existingOffers = await offerAdapter.getOffersByListingId(
+          db,
           ctx.request.body.listingId
         )
 
@@ -396,6 +397,7 @@ export const routes = (router: KoaRouter) => {
   router.get('/offers/listing-id/:listingId', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     const result = await offerAdapter.getOffersByListingId(
+      db,
       Number.parseInt(ctx.params.listingId)
     )
 

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -79,6 +79,8 @@ export const routes = (router: KoaRouter) => {
     async (ctx) => {
       const metadata = generateRouteMetadata(ctx)
       try {
+        // TODO: Maye offer adapter can handle this logic. Checking existing
+        // offers etc.
         const existingOffers =
           await offerAdapter.getOffersWithOfferApplicantsByListingId(
             db,

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -352,6 +352,7 @@ export const routes = (router: KoaRouter) => {
     const result = await offerService.denyOffer({
       applicantId: offer.data.offeredApplicant.id,
       offerId: offer.data.id,
+      listingId: offer.data.listingId,
     })
 
     if (!result.ok) {

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -79,10 +79,11 @@ export const routes = (router: KoaRouter) => {
     async (ctx) => {
       const metadata = generateRouteMetadata(ctx)
       try {
-        const existingOffers = await offerAdapter.getOffersByListingId(
-          db,
-          ctx.request.body.listingId
-        )
+        const existingOffers =
+          await offerAdapter.getOffersWithOfferApplicantsByListingId(
+            db,
+            ctx.request.body.listingId
+          )
 
         if (!existingOffers.ok) {
           ctx.status = 500
@@ -398,7 +399,7 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/offers/listing-id/:listingId', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const result = await offerAdapter.getOffersByListingId(
+    const result = await offerAdapter.getOffersWithOfferApplicantsByListingId(
       db,
       Number.parseInt(ctx.params.listingId)
     )

--- a/src/services/lease-service/routes/offers.ts
+++ b/src/services/lease-service/routes/offers.ts
@@ -91,14 +91,9 @@ export const routes = (router: KoaRouter) => {
           return
         }
 
-        const requestBody = {
-          ...ctx.request.body,
-          offerApplicants: ctx.request.body.selectedApplicants,
-        }
-
         //create initial offers if no previous offers exist
         if (!existingOffers.data.length) {
-          const offer = await offerAdapter.create(db, requestBody)
+          const offer = await offerAdapter.create(db, ctx.request.body)
           if (!offer.ok) {
             ctx.status = 500
             ctx.body = { error: 'Internal server error', ...metadata }
@@ -120,7 +115,7 @@ export const routes = (router: KoaRouter) => {
         }
 
         //create new offer if no active offers exist
-        const offer = await offerAdapter.create(db, requestBody)
+        const offer = await offerAdapter.create(db, ctx.request.body)
         if (offer.ok) {
           ctx.status = 201
           ctx.body = { content: offer.data, ...metadata }

--- a/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
@@ -1,14 +1,17 @@
+import { ApplicantStatus, ListingStatus } from 'onecore-types'
+import assert from 'node:assert'
+
 import { db, migrate, teardown } from '../../../adapters/db'
 import * as listingAdapter from '../../../adapters/listing-adapter'
 import * as factory from './../../factories'
-import { ApplicantStatus, ListingStatus } from 'onecore-types'
-import assert from 'node:assert'
 
 beforeAll(async () => {
   await migrate()
 })
 
 afterEach(async () => {
+  await db('offer_applicant').del()
+  await db('offer').del()
   await db('applicant').del()
   await db('listing').del()
 })

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -338,10 +338,23 @@ describe('offer-adapter', () => {
       expect(res.data).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
+            id: expect.any(Number),
+            sentAt: null,
+            expiresAt: expect.any(Date),
+            answeredAt: null,
             status: OfferStatus.Active,
             listingId: listing.data.id,
+            createdAt: expect.any(Date),
             offeredApplicant: expect.objectContaining({
               id: insertedApplicants[0].id,
+              name: insertedApplicants[0].name,
+              contactCode: insertedApplicants[0].contactCode,
+              applicationDate: expect.any(Date),
+              applicationType: insertedApplicants[0].applicationType,
+              status: insertedApplicants[0].status,
+              listingId: listing.data.id,
+              nationalRegistrationNumber:
+                insertedApplicants[0].nationalRegistrationNumber,
             }),
             selectedApplicants: [
               expect.objectContaining({

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -323,9 +323,9 @@ describe('offer-adapter', () => {
     })
   })
 
-  describe(offerAdapter.getOffersByListingId, () => {
+  describe(offerAdapter.getOffersWithOfferApplicantsByListingId, () => {
     it('fails correctly', async () => {
-      const res = await offerAdapter.getOffersByListingId(
+      const res = await offerAdapter.getOffersWithOfferApplicantsByListingId(
         {
           raw: jest.fn().mockRejectedValueOnce('boom'),
         } as unknown as Knex,
@@ -378,7 +378,10 @@ describe('offer-adapter', () => {
         ],
       })
 
-      const res = await offerAdapter.getOffersByListingId(db, listing.data.id)
+      const res = await offerAdapter.getOffersWithOfferApplicantsByListingId(
+        db,
+        listing.data.id
+      )
       assert(res.ok)
       expect(res.data).toEqual(
         expect.arrayContaining([

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -229,49 +229,47 @@ describe('offer-adapter', () => {
     })
   })
 
-  // describe(offerAdapter.getOfferByOfferId, () => {
-  // it('gets an offer by id', async () => {
-  // const listingRes = await listingAdapter.createListing(
-  // factory.listing.build({ rentalObjectCode: '1' })
-  // )
-  // if (!listingRes.ok) fail('Setup failed. Listing could not be completed')
+  describe(offerAdapter.getOfferByOfferId, () => {
+    it('gets an offer by id', async () => {
+      const listingRes = await listingAdapter.createListing(
+        factory.listing.build({ rentalObjectCode: '1' })
+      )
 
-  // const applicant = await listingAdapter.createApplication(
-  // factory.applicant.build({ listingId: listingRes.data.id })
-  // )
+      assert(listingRes.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listingRes.data.id })
+      )
 
-  // const offer = await offerAdapter.create(db, {
-  // expiresAt: new Date(),
-  // status: OfferStatus.Active,
-  // selectedApplicants: [
-  // factory.detailedApplicant.build({
-  // id: applicant.id,
-  // contactCode: applicant.contactCode,
-  // nationalRegistrationNumber: applicant.nationalRegistrationNumber,
-  // }),
-  // ],
-  // listingId: listingRes.data.id,
-  // applicantId: applicant.id,
-  // })
+      const offer = await offerAdapter.create(db, {
+        expiresAt: new Date(),
+        status: OfferStatus.Active,
+        offerApplicants: [
+          factory.dbOfferApplicant.build({
+            applicantId: applicant.id,
+          }),
+        ],
+        listingId: listingRes.data.id,
+        applicantId: applicant.id,
+      })
 
-  // assert(offer.ok)
-  // const res = await offerAdapter.getOfferByOfferId(offer.data.id)
+      assert(offer.ok)
+      const res = await offerAdapter.getOfferByOfferId(offer.data.id)
 
-  // expect(res.ok).toBeTruthy()
-  // if (res.ok) {
-  // expect(res.data.id).toEqual(offer.data.id)
-  // expect(res.data.offeredApplicant.contactCode).toEqual(
-  // applicant.contactCode
-  // )
-  // }
-  // })
+      expect(res.ok).toBeTruthy()
+      if (res.ok) {
+        expect(res.data.id).toEqual(offer.data.id)
+        expect(res.data.offeredApplicant.contactCode).toEqual(
+          applicant.contactCode
+        )
+      }
+    })
 
-  // it('returns empty object if offer does not exist', async () => {
-  // const res = await offerAdapter.getOfferByOfferId(123456)
-  // expect(res.ok).toBeFalsy()
-  // if (!res.ok) expect(res.err).toBe('not-found')
-  // })
-  // })
+    it('returns empty object if offer does not exist', async () => {
+      const res = await offerAdapter.getOfferByOfferId(123456)
+      expect(res.ok).toBeFalsy()
+      if (!res.ok) expect(res.err).toBe('not-found')
+    })
+  })
 
   describe(offerAdapter.getOffersByListingId, () => {
     it('fails correctly', async () => {

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -23,7 +23,7 @@ afterAll(async () => {
 })
 
 describe('offer-adapter', () => {
-  describe.only(offerAdapter.create, () => {
+  describe(offerAdapter.create, () => {
     it('fails gracefully if applicant not found', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
@@ -95,19 +95,19 @@ describe('offer-adapter', () => {
         factory.applicant.build({ listingId: listing.data.id })
       )
 
-      await offerAdapter.create(db, {
+      const insertOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
-            id: applicant.id,
-            contactCode: applicant.contactCode,
-            nationalRegistrationNumber: applicant.nationalRegistrationNumber,
+        offerApplicants: [
+          factory.dbOfferApplicant.build({
+            applicantId: applicant.id,
           }),
         ],
         listingId: listing.data.id,
         applicantId: applicant.id,
       })
+
+      assert(insertOffer.ok)
 
       const offersFromDb = await offerAdapter.getOffersForContact(
         applicant.contactCode
@@ -127,19 +127,19 @@ describe('offer-adapter', () => {
         factory.applicant.build({ listingId: listing.data.id })
       )
 
-      await offerAdapter.create(db, {
+      const insertOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
-            id: applicant.id,
-            contactCode: applicant.contactCode,
-            nationalRegistrationNumber: applicant.nationalRegistrationNumber,
+        offerApplicants: [
+          factory.dbOfferApplicant.build({
+            applicantId: applicant.id,
           }),
         ],
         listingId: listing.data.id,
         applicantId: applicant.id,
       })
+
+      assert(insertOffer.ok)
 
       const offersFromDb = await offerAdapter.getOffersForContact(
         'NON_EXISTING_CONTACT_CODE'
@@ -149,140 +149,142 @@ describe('offer-adapter', () => {
     })
   })
 
-  describe(offerAdapter.getOfferByContactCodeAndOfferId, () => {
-    it('gets the offer a a contact', async () => {
-      const listing = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
-      )
-      assert(listing.ok)
-      const applicant = await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listing.data.id })
-      )
+  // describe(offerAdapter.getOfferByContactCodeAndOfferId, () => {
+  // it('gets the offer a a contact', async () => {
+  // const listing = await listingAdapter.createListing(
+  // factory.listing.build({ rentalObjectCode: '1' })
+  // )
+  // assert(listing.ok)
+  // const applicant = await listingAdapter.createApplication(
+  // factory.applicant.build({ listingId: listing.data.id })
+  // )
 
-      const offer = await offerAdapter.create(db, {
-        expiresAt: new Date(),
-        status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
-            id: applicant.id,
-            contactCode: applicant.contactCode,
-            nationalRegistrationNumber: applicant.nationalRegistrationNumber,
-          }),
-        ],
-        listingId: listing.data.id,
-        applicantId: applicant.id,
-      })
+  // const offer = await offerAdapter.create(db, {
+  // expiresAt: new Date(),
+  // status: OfferStatus.Active,
+  // selectedApplicants: [
+  // factory.detailedApplicant.build({
+  // id: applicant.id,
+  // contactCode: applicant.contactCode,
+  // nationalRegistrationNumber: applicant.nationalRegistrationNumber,
+  // }),
+  // ],
+  // listingId: listing.data.id,
+  // applicantId: applicant.id,
+  // })
 
-      assert(offer.ok)
-      const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
-        applicant.contactCode,
-        offer.data.id
-      )
-      expect(offersFromDb).toBeDefined()
-      expect(offersFromDb?.id).toEqual(offer.data.id)
-      expect(offersFromDb?.offeredApplicant.contactCode).toEqual(
-        applicant.contactCode
-      )
-    })
+  // assert(offer.ok)
+  // const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
+  // applicant.contactCode,
+  // offer.data.id
+  // )
+  // expect(offersFromDb).toBeDefined()
+  // expect(offersFromDb?.id).toEqual(offer.data.id)
+  // expect(offersFromDb?.offeredApplicant.contactCode).toEqual(
+  // applicant.contactCode
+  // )
+  // })
 
-    it('returns empty object if offer does not exist', async () => {
-      const listing = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
-      )
-      assert(listing.ok)
-      const applicant = await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listing.data.id })
-      )
+  // it('returns empty object if offer does not exist', async () => {
+  // const listing = await listingAdapter.createListing(
+  // factory.listing.build({ rentalObjectCode: '1' })
+  // )
+  // assert(listing.ok)
+  // const applicant = await listingAdapter.createApplication(
+  // factory.applicant.build({ listingId: listing.data.id })
+  // )
 
-      const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
-        applicant.contactCode,
-        123456
-      )
-      expect(offersFromDb).toBeUndefined()
-    })
+  // const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
+  // applicant.contactCode,
+  // 123456
+  // )
+  // expect(offersFromDb).toBeUndefined()
+  // })
 
-    it('returns empty object if applicant does not exist', async () => {
-      const listing = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
-      )
-      assert(listing.ok)
-      const applicant = await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listing.data.id })
-      )
+  // it('returns empty object if applicant does not exist', async () => {
+  // const listing = await listingAdapter.createListing(
+  // factory.listing.build({ rentalObjectCode: '1' })
+  // )
+  // assert(listing.ok)
+  // const applicant = await listingAdapter.createApplication(
+  // factory.applicant.build({ listingId: listing.data.id })
+  // )
 
-      const offer = await offerAdapter.create(db, {
-        expiresAt: new Date(),
-        status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
-            id: applicant.id,
-            contactCode: applicant.contactCode,
-            nationalRegistrationNumber: applicant.nationalRegistrationNumber,
-          }),
-        ],
-        listingId: listing.data.id,
-        applicantId: applicant.id,
-      })
+  // const offer = await offerAdapter.create(db, {
+  // expiresAt: new Date(),
+  // status: OfferStatus.Active,
+  // selectedApplicants: [
+  // factory.detailedApplicant.build({
+  // id: applicant.id,
+  // contactCode: applicant.contactCode,
+  // nationalRegistrationNumber: applicant.nationalRegistrationNumber,
+  // }),
+  // ],
+  // listingId: listing.data.id,
+  // applicantId: applicant.id,
+  // })
 
-      assert(offer.ok)
-      const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
-        'NON_EXISTING_CONTACT_CODE',
-        offer.data.id
-      )
-      expect(offersFromDb).toBeUndefined()
-    })
-  })
+  // assert(offer.ok)
+  // const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
+  // 'NON_EXISTING_CONTACT_CODE',
+  // offer.data.id
+  // )
+  // expect(offersFromDb).toBeUndefined()
+  // })
+  // })
 
-  describe(offerAdapter.getOfferByOfferId, () => {
-    it('gets an offer by id', async () => {
-      const listingRes = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
-      )
-      if (!listingRes.ok) fail('Setup failed. Listing could not be completed')
+  // describe(offerAdapter.getOfferByOfferId, () => {
+  // it('gets an offer by id', async () => {
+  // const listingRes = await listingAdapter.createListing(
+  // factory.listing.build({ rentalObjectCode: '1' })
+  // )
+  // if (!listingRes.ok) fail('Setup failed. Listing could not be completed')
 
-      const applicant = await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listingRes.data.id })
-      )
+  // const applicant = await listingAdapter.createApplication(
+  // factory.applicant.build({ listingId: listingRes.data.id })
+  // )
 
-      const offer = await offerAdapter.create(db, {
-        expiresAt: new Date(),
-        status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
-            id: applicant.id,
-            contactCode: applicant.contactCode,
-            nationalRegistrationNumber: applicant.nationalRegistrationNumber,
-          }),
-        ],
-        listingId: listingRes.data.id,
-        applicantId: applicant.id,
-      })
+  // const offer = await offerAdapter.create(db, {
+  // expiresAt: new Date(),
+  // status: OfferStatus.Active,
+  // selectedApplicants: [
+  // factory.detailedApplicant.build({
+  // id: applicant.id,
+  // contactCode: applicant.contactCode,
+  // nationalRegistrationNumber: applicant.nationalRegistrationNumber,
+  // }),
+  // ],
+  // listingId: listingRes.data.id,
+  // applicantId: applicant.id,
+  // })
 
-      assert(offer.ok)
-      const res = await offerAdapter.getOfferByOfferId(offer.data.id)
+  // assert(offer.ok)
+  // const res = await offerAdapter.getOfferByOfferId(offer.data.id)
 
-      expect(res.ok).toBeTruthy()
-      if (res.ok) {
-        expect(res.data.id).toEqual(offer.data.id)
-        expect(res.data.offeredApplicant.contactCode).toEqual(
-          applicant.contactCode
-        )
-      }
-    })
+  // expect(res.ok).toBeTruthy()
+  // if (res.ok) {
+  // expect(res.data.id).toEqual(offer.data.id)
+  // expect(res.data.offeredApplicant.contactCode).toEqual(
+  // applicant.contactCode
+  // )
+  // }
+  // })
 
-    it('returns empty object if offer does not exist', async () => {
-      const res = await offerAdapter.getOfferByOfferId(123456)
-      expect(res.ok).toBeFalsy()
-      if (!res.ok) expect(res.err).toBe('not-found')
-    })
-  })
+  // it('returns empty object if offer does not exist', async () => {
+  // const res = await offerAdapter.getOfferByOfferId(123456)
+  // expect(res.ok).toBeFalsy()
+  // if (!res.ok) expect(res.err).toBe('not-found')
+  // })
+  // })
 
   describe(offerAdapter.getOffersByListingId, () => {
     it('fails correctly', async () => {
-      const res = await offerAdapter.getOffersByListingId(1, {
-        select: jest.fn().mockRejectedValueOnce('boom'),
-      } as unknown as Knex)
-
+      const res = await offerAdapter.getOffersByListingId(
+        {
+          raw: jest.fn().mockRejectedValueOnce('boom'),
+        } as unknown as Knex,
+        1
+      )
       expect(res).toEqual({ ok: false, err: 'unknown' })
     })
 
@@ -330,7 +332,7 @@ describe('offer-adapter', () => {
         ],
       })
 
-      const res = await offerAdapter.getOffersByListingId(listing.data.id)
+      const res = await offerAdapter.getOffersByListingId(db, listing.data.id)
       assert(res.ok)
       expect(res.data).toEqual(
         expect.arrayContaining([

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -25,24 +25,7 @@ afterAll(async () => {
 })
 
 describe('offer-adapter', () => {
-  describe(offerAdapter.create, () => {
-    it('fails if applicant does not exist', async () => {
-      const listing = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
-      )
-      assert(listing.ok)
-
-      const insertedOffer = await offerAdapter.create(db, {
-        expiresAt: new Date(),
-        status: OfferStatus.Active,
-        selectedApplicants: [],
-        listingId: listing.data.id,
-        applicantId: -1,
-      })
-
-      expect(insertedOffer).toEqual({ ok: false, err: 'no-applicant' })
-    })
-
+  describe.only(offerAdapter.create, () => {
     it('inserts a new offer in the database', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
@@ -59,20 +42,16 @@ describe('offer-adapter', () => {
       const insertedOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
-            id: applicant_one.id,
-            contactCode: applicant_one.contactCode,
-            nationalRegistrationNumber:
-              applicant_one.nationalRegistrationNumber,
-            priority: 1,
+        offerApplicants: [
+          factory.offerApplicant.build({
+            listingId: listing.data.id,
+            applicantId: applicant_one.id,
+            applicantPriority: 2,
           }),
-          factory.detailedApplicant.build({
-            id: applicant_two.id,
-            contactCode: applicant_two.contactCode,
-            nationalRegistrationNumber:
-              applicant_one.nationalRegistrationNumber,
-            priority: 1,
+          factory.offerApplicant.build({
+            listingId: listing.data.id,
+            applicantId: applicant_two.id,
+            applicantPriority: 2,
           }),
         ],
         listingId: listing.data.id,
@@ -86,7 +65,7 @@ describe('offer-adapter', () => {
       expect(offerApplicants).toHaveLength(2)
     })
 
-    it('throws error if applicant not found', async () => {
+    it('fails gracefully if applicant not found', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
       )

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -338,9 +338,10 @@ describe('offer-adapter', () => {
       )
       assert(listing.ok)
 
-      const applicants = factory.applicant.buildList(2, {
-        listingId: listing.data.id,
-      })
+      const applicants = [
+        factory.applicant.build({ listingId: listing.data.id, name: 'A' }),
+        factory.applicant.build({ listingId: listing.data.id, name: 'B' }),
+      ]
 
       const insertedApplicants = await Promise.all(
         applicants.map(listingAdapter.createApplication)

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -33,7 +33,7 @@ describe('offer-adapter', () => {
       const offer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             id: -1,
           }),
@@ -60,7 +60,7 @@ describe('offer-adapter', () => {
       const insertedOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: applicant_one.id,
@@ -102,7 +102,7 @@ describe('offer-adapter', () => {
       const insertedOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [offerApplicant],
+        selectedApplicants: [offerApplicant],
         listingId: listing.data.id,
         applicantId: applicant_one.id,
       })
@@ -110,11 +110,11 @@ describe('offer-adapter', () => {
       assert(insertedOffer.ok)
       expect(insertedOffer.data.listingId).toEqual(insertedOffer.data.listingId)
       expect(insertedOffer.data.offeredApplicant.id).toEqual(applicant_one.id)
-      const offerApplicantsFromDb = await db.raw(
+      const selectedApplicantsFromDb = await db.raw(
         'SELECT * FROM offer_applicant ORDER BY sortOrder ASC'
       )
 
-      expect(offerApplicantsFromDb).toEqual([
+      expect(selectedApplicantsFromDb).toEqual([
         {
           id: expect.any(Number),
           listingId: listing.data.id,
@@ -148,7 +148,7 @@ describe('offer-adapter', () => {
       const insertOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             applicantId: applicant.id,
           }),
@@ -180,7 +180,7 @@ describe('offer-adapter', () => {
       const insertOffer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             applicantId: applicant.id,
           }),
@@ -212,7 +212,7 @@ describe('offer-adapter', () => {
       const offer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             applicantId: applicant.id,
           }),
@@ -261,7 +261,7 @@ describe('offer-adapter', () => {
       const offer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             applicantId: applicant.id,
           }),
@@ -293,7 +293,7 @@ describe('offer-adapter', () => {
       const offer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             applicantId: applicant.id,
           }),
@@ -351,7 +351,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         listingId: listing.data.id,
         applicantId: insertedApplicants[0].id,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[0].id,
@@ -368,7 +368,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         listingId: listing.data.id,
         applicantId: insertedApplicants[1].id,
-        offerApplicants: [
+        selectedApplicants: [
           factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[1].id,

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -280,7 +280,7 @@ describe('offer-adapter', () => {
     })
   })
 
-  describe.only(offerAdapter.getOffersByListingId, () => {
+  describe(offerAdapter.getOffersByListingId, () => {
     it('fails correctly', async () => {
       const res = await offerAdapter.getOffersByListingId(1, {
         select: jest.fn().mockRejectedValueOnce('boom'),
@@ -289,7 +289,7 @@ describe('offer-adapter', () => {
       expect(res).toEqual({ ok: false, err: 'unknown' })
     })
 
-    it('gets offers by listing id', async () => {
+    it.only('gets offers by listing id', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
       )
@@ -309,11 +309,11 @@ describe('offer-adapter', () => {
         listingId: listing.data.id,
         applicantId: insertedApplicants[0].id,
         offerApplicants: [
-          factory.offerApplicant.build({
+          factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[0].id,
           }),
-          factory.offerApplicant.build({
+          factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[1].id,
           }),
@@ -326,7 +326,7 @@ describe('offer-adapter', () => {
         listingId: listing.data.id,
         applicantId: insertedApplicants[1].id,
         offerApplicants: [
-          factory.offerApplicant.build({
+          factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[1].id,
           }),
@@ -359,11 +359,11 @@ describe('offer-adapter', () => {
             selectedApplicants: [
               expect.objectContaining({
                 applicantId: insertedApplicants[0].id,
-                applicantApplicationDate: expect.any(Date),
+                applicationDate: expect.any(Date),
               }),
               expect.objectContaining({
                 applicantId: insertedApplicants[1].id,
-                applicantApplicationDate: expect.any(Date),
+                applicationDate: expect.any(Date),
               }),
             ],
           }),
@@ -376,7 +376,7 @@ describe('offer-adapter', () => {
             selectedApplicants: [
               expect.objectContaining({
                 applicantId: insertedApplicants[1].id,
-                applicantApplicationDate: expect.any(Date),
+                applicationDate: expect.any(Date),
               }),
             ],
           }),

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -34,7 +34,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             id: -1,
           }),
         ],
@@ -61,16 +61,15 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             listingId: listing.data.id,
             applicantId: applicant_one.id,
-            applicantPriority: 2,
-            sortOrder: 1,
+            priority: 2,
           }),
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             listingId: listing.data.id,
             applicantId: applicant_two.id,
-            applicantPriority: 2,
+            priority: 2,
             sortOrder: 2,
           }),
         ],
@@ -96,10 +95,10 @@ describe('offer-adapter', () => {
         factory.applicant.build({ listingId: listing.data.id })
       )
 
-      const offerApplicant = factory.dbOfferApplicant.build({
+      const offerApplicant = factory.offerApplicant.build({
         listingId: listing.data.id,
         applicantId: applicant_one.id,
-        applicantPriority: 2,
+        priority: 2,
         sortOrder: 1,
       })
 
@@ -122,14 +121,13 @@ describe('offer-adapter', () => {
           listingId: listing.data.id,
           offerId: insertedOffer.data.id,
           applicantId: applicant_one.id,
-          applicantStatus: offerApplicant.applicantStatus,
-          applicantApplicationType: offerApplicant.applicantApplicationType,
-          applicantQueuePoints: offerApplicant.applicantQueuePoints,
-          applicantAddress: offerApplicant.applicantAddress,
+          applicantStatus: offerApplicant.status,
+          applicantApplicationType: offerApplicant.applicationType,
+          applicantQueuePoints: offerApplicant.queuePoints,
+          applicantAddress: offerApplicant.address,
           applicantHasParkingSpace: true,
-          applicantHousingLeaseStatus:
-            offerApplicant.applicantHousingLeaseStatus,
-          applicantPriority: offerApplicant.applicantPriority,
+          applicantHousingLeaseStatus: offerApplicant.housingLeaseStatus,
+          applicantPriority: offerApplicant.priority,
           createdAt: expect.any(Date),
           sortOrder: 1,
         },
@@ -151,7 +149,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             applicantId: applicant.id,
           }),
         ],
@@ -183,7 +181,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             applicantId: applicant.id,
           }),
         ],
@@ -215,7 +213,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             applicantId: applicant.id,
           }),
         ],
@@ -264,7 +262,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             applicantId: applicant.id,
           }),
         ],
@@ -296,7 +294,7 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             applicantId: applicant.id,
           }),
         ],
@@ -354,11 +352,11 @@ describe('offer-adapter', () => {
         listingId: listing.data.id,
         applicantId: insertedApplicants[0].id,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[0].id,
           }),
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[1].id,
           }),
@@ -371,7 +369,7 @@ describe('offer-adapter', () => {
         listingId: listing.data.id,
         applicantId: insertedApplicants[1].id,
         selectedApplicants: [
-          factory.dbOfferApplicant.build({
+          factory.offerApplicant.build({
             listingId: listing.data.id,
             applicantId: insertedApplicants[1].id,
           }),

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -24,6 +24,23 @@ afterAll(async () => {
 
 describe('offer-adapter', () => {
   describe(offerAdapter.create, () => {
+    it('fails if applicant does not exist', async () => {
+      const listing = await listingAdapter.createListing(
+        factory.listing.build({ rentalObjectCode: '1' })
+      )
+      assert(listing.ok)
+
+      const insertedOffer = await offerAdapter.create(db, {
+        expiresAt: new Date(),
+        status: OfferStatus.Active,
+        selectedApplicants: [],
+        listingId: listing.data.id,
+        applicantId: -1,
+      })
+
+      expect(insertedOffer).toEqual({ ok: false, err: 'no-applicant' })
+    })
+
     it('inserts a new offer in the database', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
@@ -330,7 +347,6 @@ describe('offer-adapter', () => {
       const res = await offerAdapter.getOffersByListingId(listing.data.id)
       assert(res.ok)
 
-      console.log(res.data)
       expect(res.data).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -346,7 +346,7 @@ describe('offer-adapter', () => {
         applicants.map(listingAdapter.createApplication)
       )
 
-      await offerAdapter.create(db, {
+      const insertedOffer_1 = await offerAdapter.create(db, {
         status: OfferStatus.Active,
         expiresAt: new Date(),
         listingId: listing.data.id,
@@ -363,7 +363,7 @@ describe('offer-adapter', () => {
         ],
       })
 
-      await offerAdapter.create(db, {
+      const insertedOffer_2 = await offerAdapter.create(db, {
         status: OfferStatus.Expired,
         expiresAt: new Date(),
         listingId: listing.data.id,
@@ -376,58 +376,63 @@ describe('offer-adapter', () => {
         ],
       })
 
+      assert(insertedOffer_1.ok)
+      assert(insertedOffer_2.ok)
+
       const res = await offerAdapter.getOffersWithOfferApplicantsByListingId(
         db,
         listing.data.id
       )
       assert(res.ok)
-      expect(res.data).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: expect.any(Number),
-            sentAt: null,
-            expiresAt: expect.any(Date),
-            answeredAt: null,
-            status: OfferStatus.Active,
+      expect(res.data).toEqual([
+        expect.objectContaining({
+          id: insertedOffer_1.data.id,
+          sentAt: null,
+          expiresAt: expect.any(Date),
+          answeredAt: null,
+          status: OfferStatus.Active,
+          listingId: listing.data.id,
+          createdAt: expect.any(Date),
+          offeredApplicant: expect.objectContaining({
+            id: insertedApplicants[0].id,
+            name: insertedApplicants[0].name,
+            contactCode: insertedApplicants[0].contactCode,
+            applicationDate: expect.any(Date),
+            applicationType: insertedApplicants[0].applicationType,
+            status: insertedApplicants[0].status,
             listingId: listing.data.id,
-            createdAt: expect.any(Date),
-            offeredApplicant: expect.objectContaining({
-              id: insertedApplicants[0].id,
-              name: insertedApplicants[0].name,
-              contactCode: insertedApplicants[0].contactCode,
+            nationalRegistrationNumber:
+              insertedApplicants[0].nationalRegistrationNumber,
+          }),
+          selectedApplicants: [
+            expect.objectContaining({
+              applicantId: insertedApplicants[0].id,
               applicationDate: expect.any(Date),
-              applicationType: insertedApplicants[0].applicationType,
-              status: insertedApplicants[0].status,
-              listingId: listing.data.id,
-              nationalRegistrationNumber:
-                insertedApplicants[0].nationalRegistrationNumber,
+              name: insertedApplicants[0].name,
             }),
-            selectedApplicants: [
-              expect.objectContaining({
-                applicantId: insertedApplicants[0].id,
-                applicationDate: expect.any(Date),
-              }),
-              expect.objectContaining({
-                applicantId: insertedApplicants[1].id,
-                applicationDate: expect.any(Date),
-              }),
-            ],
-          }),
-          expect.objectContaining({
-            status: OfferStatus.Expired,
-            listingId: listing.data.id,
-            offeredApplicant: expect.objectContaining({
-              id: insertedApplicants[1].id,
+            expect.objectContaining({
+              applicantId: insertedApplicants[1].id,
+              applicationDate: expect.any(Date),
+              name: insertedApplicants[1].name,
             }),
-            selectedApplicants: [
-              expect.objectContaining({
-                applicantId: insertedApplicants[1].id,
-                applicationDate: expect.any(Date),
-              }),
-            ],
+          ],
+        }),
+        expect.objectContaining({
+          id: insertedOffer_2.data.id,
+          status: OfferStatus.Expired,
+          listingId: listing.data.id,
+          offeredApplicant: expect.objectContaining({
+            id: insertedApplicants[1].id,
           }),
-        ])
-      )
+          selectedApplicants: [
+            expect.objectContaining({
+              applicantId: insertedApplicants[1].id,
+              applicationDate: expect.any(Date),
+              name: insertedApplicants[1].name,
+            }),
+          ],
+        }),
+      ])
     })
   })
 })

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -290,7 +290,7 @@ describe('offer-adapter', () => {
       expect(res).toEqual({ ok: false, err: 'unknown' })
     })
 
-    it.only('gets offers by listing id', async () => {
+    it('gets offers by listing id', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
       )

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -149,89 +149,85 @@ describe('offer-adapter', () => {
     })
   })
 
-  // describe(offerAdapter.getOfferByContactCodeAndOfferId, () => {
-  // it('gets the offer a a contact', async () => {
-  // const listing = await listingAdapter.createListing(
-  // factory.listing.build({ rentalObjectCode: '1' })
-  // )
-  // assert(listing.ok)
-  // const applicant = await listingAdapter.createApplication(
-  // factory.applicant.build({ listingId: listing.data.id })
-  // )
+  describe(offerAdapter.getOfferByContactCodeAndOfferId, () => {
+    it('gets the offer a a contact', async () => {
+      const listing = await listingAdapter.createListing(
+        factory.listing.build({ rentalObjectCode: '1' })
+      )
+      assert(listing.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listing.data.id })
+      )
 
-  // const offer = await offerAdapter.create(db, {
-  // expiresAt: new Date(),
-  // status: OfferStatus.Active,
-  // selectedApplicants: [
-  // factory.detailedApplicant.build({
-  // id: applicant.id,
-  // contactCode: applicant.contactCode,
-  // nationalRegistrationNumber: applicant.nationalRegistrationNumber,
-  // }),
-  // ],
-  // listingId: listing.data.id,
-  // applicantId: applicant.id,
-  // })
+      const offer = await offerAdapter.create(db, {
+        expiresAt: new Date(),
+        status: OfferStatus.Active,
+        offerApplicants: [
+          factory.dbOfferApplicant.build({
+            applicantId: applicant.id,
+          }),
+        ],
+        listingId: listing.data.id,
+        applicantId: applicant.id,
+      })
 
-  // assert(offer.ok)
-  // const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
-  // applicant.contactCode,
-  // offer.data.id
-  // )
-  // expect(offersFromDb).toBeDefined()
-  // expect(offersFromDb?.id).toEqual(offer.data.id)
-  // expect(offersFromDb?.offeredApplicant.contactCode).toEqual(
-  // applicant.contactCode
-  // )
-  // })
+      assert(offer.ok)
+      const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
+        applicant.contactCode,
+        offer.data.id
+      )
+      expect(offersFromDb).toBeDefined()
+      expect(offersFromDb?.id).toEqual(offer.data.id)
+      expect(offersFromDb?.offeredApplicant.contactCode).toEqual(
+        applicant.contactCode
+      )
+    })
 
-  // it('returns empty object if offer does not exist', async () => {
-  // const listing = await listingAdapter.createListing(
-  // factory.listing.build({ rentalObjectCode: '1' })
-  // )
-  // assert(listing.ok)
-  // const applicant = await listingAdapter.createApplication(
-  // factory.applicant.build({ listingId: listing.data.id })
-  // )
+    it('returns empty object if offer does not exist', async () => {
+      const listing = await listingAdapter.createListing(
+        factory.listing.build({ rentalObjectCode: '1' })
+      )
+      assert(listing.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listing.data.id })
+      )
 
-  // const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
-  // applicant.contactCode,
-  // 123456
-  // )
-  // expect(offersFromDb).toBeUndefined()
-  // })
+      const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
+        applicant.contactCode,
+        123456
+      )
+      expect(offersFromDb).toBeUndefined()
+    })
 
-  // it('returns empty object if applicant does not exist', async () => {
-  // const listing = await listingAdapter.createListing(
-  // factory.listing.build({ rentalObjectCode: '1' })
-  // )
-  // assert(listing.ok)
-  // const applicant = await listingAdapter.createApplication(
-  // factory.applicant.build({ listingId: listing.data.id })
-  // )
+    it('returns empty object if applicant does not exist', async () => {
+      const listing = await listingAdapter.createListing(
+        factory.listing.build({ rentalObjectCode: '1' })
+      )
+      assert(listing.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listing.data.id })
+      )
 
-  // const offer = await offerAdapter.create(db, {
-  // expiresAt: new Date(),
-  // status: OfferStatus.Active,
-  // selectedApplicants: [
-  // factory.detailedApplicant.build({
-  // id: applicant.id,
-  // contactCode: applicant.contactCode,
-  // nationalRegistrationNumber: applicant.nationalRegistrationNumber,
-  // }),
-  // ],
-  // listingId: listing.data.id,
-  // applicantId: applicant.id,
-  // })
+      const offer = await offerAdapter.create(db, {
+        expiresAt: new Date(),
+        status: OfferStatus.Active,
+        offerApplicants: [
+          factory.dbOfferApplicant.build({
+            applicantId: applicant.id,
+          }),
+        ],
+        listingId: listing.data.id,
+        applicantId: applicant.id,
+      })
 
-  // assert(offer.ok)
-  // const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
-  // 'NON_EXISTING_CONTACT_CODE',
-  // offer.data.id
-  // )
-  // expect(offersFromDb).toBeUndefined()
-  // })
-  // })
+      assert(offer.ok)
+      const offersFromDb = await offerAdapter.getOfferByContactCodeAndOfferId(
+        'NON_EXISTING_CONTACT_CODE',
+        offer.data.id
+      )
+      expect(offersFromDb).toBeUndefined()
+    })
+  })
 
   // describe(offerAdapter.getOfferByOfferId, () => {
   // it('gets an offer by id', async () => {

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { OfferStatus } from 'onecore-types'
 import assert from 'node:assert'
 
@@ -309,7 +311,7 @@ describe('offer-adapter', () => {
       expect(res).toEqual({ ok: false, err: 'unknown' })
     })
 
-    it.only('gets offers by listing id', async () => {
+    it('gets offers by listing id', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
       )
@@ -329,8 +331,15 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         listingId: listing.data.id,
         applicantId: insertedApplicants[0].id,
-        selectedApplicants: [
-          factory.detailedApplicant.build({ id: insertedApplicants[0].id }),
+        offerApplicants: [
+          factory.offerApplicant.build({
+            listingId: listing.data.id,
+            applicantId: insertedApplicants[0].id,
+          }),
+          factory.offerApplicant.build({
+            listingId: listing.data.id,
+            applicantId: insertedApplicants[1].id,
+          }),
         ],
       })
 

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -79,8 +79,12 @@ describe('offer-adapter', () => {
       })
 
       assert(insertedOffer.ok)
-      expect(insertedOffer.data.listingId).toEqual(insertedOffer.data.listingId)
-      expect(insertedOffer.data.offeredApplicant.id).toEqual(applicant_one.id)
+      const [offerFromDb] = await db.raw(
+        `SELECT * from offer WHERE id = ${insertedOffer.data.id}`
+      )
+
+      expect(offerFromDb.ListingId).toEqual(listing.data.id)
+      expect(offerFromDb.ApplicantId).toEqual(applicant_one.id)
     })
 
     it('inserts offer applicants', async () => {
@@ -108,8 +112,6 @@ describe('offer-adapter', () => {
       })
 
       assert(insertedOffer.ok)
-      expect(insertedOffer.data.listingId).toEqual(insertedOffer.data.listingId)
-      expect(insertedOffer.data.offeredApplicant.id).toEqual(applicant_one.id)
       const selectedApplicantsFromDb = await db.raw(
         'SELECT * FROM offer_applicant ORDER BY sortOrder ASC'
       )

--- a/src/services/lease-service/tests/adapters/offer-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/offer-adapter.test.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import { OfferStatus } from 'onecore-types'
 import assert from 'node:assert'
 import { Knex } from 'knex'
@@ -25,7 +23,7 @@ afterAll(async () => {
 })
 
 describe('offer-adapter', () => {
-  describe(offerAdapter.create, () => {
+  describe.only(offerAdapter.create, () => {
     it('fails gracefully if applicant not found', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
@@ -35,11 +33,9 @@ describe('offer-adapter', () => {
       const offer = await offerAdapter.create(db, {
         expiresAt: new Date(),
         status: OfferStatus.Active,
-        selectedApplicants: [
-          factory.detailedApplicant.build({
+        offerApplicants: [
+          factory.dbOfferApplicant.build({
             id: -1,
-            contactCode: 'NON_EXISTING_APPLICANT',
-            nationalRegistrationNumber: 'I_DO_NOT_EXIST',
           }),
         ],
         listingId: listing.data.id,
@@ -65,12 +61,12 @@ describe('offer-adapter', () => {
         expiresAt: new Date(),
         status: OfferStatus.Active,
         offerApplicants: [
-          factory.offerApplicant.build({
+          factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: applicant_one.id,
             applicantPriority: 2,
           }),
-          factory.offerApplicant.build({
+          factory.dbOfferApplicant.build({
             listingId: listing.data.id,
             applicantId: applicant_two.id,
             applicantPriority: 2,
@@ -90,7 +86,7 @@ describe('offer-adapter', () => {
   })
 
   describe(offerAdapter.getOffersForContact, () => {
-    it('gets the offers a a contact', async () => {
+    it('gets the offers for a contact', async () => {
       const listing = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
       )

--- a/src/services/lease-service/tests/factories/index.ts
+++ b/src/services/lease-service/tests/factories/index.ts
@@ -8,4 +8,7 @@ export { OfferWithRentalObjectCodeFactory as offerWithRentalObjectCode } from '.
 export { DetailedOfferFactory as detailedOffer } from './offer'
 export { SoapInternalParkingSpaceFactory as soapInternalParkingSpace } from './soap-parking-space'
 export { TenantFactory as tenant } from './tenant'
-export { OfferApplicantFactory as offerApplicant } from './offer-applicant'
+export {
+  OfferApplicantFactory as offerApplicant,
+  DbOfferApplicantFactory as dbOfferApplicant,
+} from './offer-applicant'

--- a/src/services/lease-service/tests/factories/index.ts
+++ b/src/services/lease-service/tests/factories/index.ts
@@ -8,3 +8,4 @@ export { OfferWithRentalObjectCodeFactory as offerWithRentalObjectCode } from '.
 export { DetailedOfferFactory as detailedOffer } from './offer'
 export { SoapInternalParkingSpaceFactory as soapInternalParkingSpace } from './soap-parking-space'
 export { TenantFactory as tenant } from './tenant'
+export { OfferApplicantFactory as offerApplicant } from './offer-applicant'

--- a/src/services/lease-service/tests/factories/index.ts
+++ b/src/services/lease-service/tests/factories/index.ts
@@ -8,7 +8,4 @@ export { OfferWithRentalObjectCodeFactory as offerWithRentalObjectCode } from '.
 export { DetailedOfferFactory as detailedOffer } from './offer'
 export { SoapInternalParkingSpaceFactory as soapInternalParkingSpace } from './soap-parking-space'
 export { TenantFactory as tenant } from './tenant'
-export {
-  OfferApplicantFactory as offerApplicant,
-  DbOfferApplicantFactory as dbOfferApplicant,
-} from './offer-applicant'
+export { OfferApplicantFactory as offerApplicant } from './offer-applicant'

--- a/src/services/lease-service/tests/factories/offer-applicant.ts
+++ b/src/services/lease-service/tests/factories/offer-applicant.ts
@@ -17,6 +17,7 @@ export const OfferApplicantFactory = Factory.define<OfferApplicant>(
     applicantHasParkingSpace: true,
     applicantHousingLeaseStatus: LeaseStatus.Current,
     createdAt: new Date(),
+    applicantApplicationDate: new Date(),
     sortOrder: sequence,
   })
 )

--- a/src/services/lease-service/tests/factories/offer-applicant.ts
+++ b/src/services/lease-service/tests/factories/offer-applicant.ts
@@ -17,8 +17,10 @@ export const OfferApplicantFactory = Factory.define<OfferApplicant>(
     hasParkingSpace: true,
     housingLeaseStatus: LeaseStatus.Current,
     createdAt: new Date(),
-    applicationDate: new Date(),
     sortOrder: sequence,
+
+    applicationDate: new Date(),
+    name: 'Test Testsson',
   })
 )
 

--- a/src/services/lease-service/tests/factories/offer-applicant.ts
+++ b/src/services/lease-service/tests/factories/offer-applicant.ts
@@ -1,8 +1,5 @@
 import { Factory } from 'fishery'
-import { ApplicantStatus, LeaseStatus } from 'onecore-types'
-// TODO: import from onecore-types
-import { OfferApplicant } from '../../adapters/offer-adapter'
-import { DbOfferApplicant } from '../../adapters/types'
+import { ApplicantStatus, LeaseStatus, OfferApplicant } from 'onecore-types'
 
 export const OfferApplicantFactory = Factory.define<OfferApplicant>(
   ({ sequence }) => ({
@@ -22,24 +19,5 @@ export const OfferApplicantFactory = Factory.define<OfferApplicant>(
 
     applicationDate: new Date(),
     name: 'Test Testsson',
-  })
-)
-
-export const DbOfferApplicantFactory = Factory.define<DbOfferApplicant>(
-  ({ sequence }) => ({
-    id: sequence,
-    listingId: 1,
-    offerId: 1,
-    applicantId: 1,
-    applicantPriority: 1,
-    applicantQueuePoints: 1,
-    applicantStatus: ApplicantStatus.Active,
-    applicantAddress: 'Testgatan 14',
-    applicantApplicationType: 'Additional',
-    applicantHasParkingSpace: true,
-    applicantHousingLeaseStatus: LeaseStatus.Current,
-    createdAt: new Date(),
-    applicantApplicationDate: new Date(),
-    sortOrder: sequence,
   })
 )

--- a/src/services/lease-service/tests/factories/offer-applicant.ts
+++ b/src/services/lease-service/tests/factories/offer-applicant.ts
@@ -1,9 +1,28 @@
 import { Factory } from 'fishery'
 import { ApplicantStatus, LeaseStatus } from 'onecore-types'
 // TODO: import from onecore-types
-import { OfferApplicant } from '../../adapters/offer-adapter'
+import { DbOfferApplicant, OfferApplicant } from '../../adapters/offer-adapter'
 
 export const OfferApplicantFactory = Factory.define<OfferApplicant>(
+  ({ sequence }) => ({
+    id: sequence,
+    listingId: 1,
+    offerId: 1,
+    applicantId: 1,
+    priority: 1,
+    queuePoints: 1,
+    status: ApplicantStatus.Active,
+    address: 'Testgatan 14',
+    applicationType: 'Additional',
+    hasParkingSpace: true,
+    housingLeaseStatus: LeaseStatus.Current,
+    createdAt: new Date(),
+    applicationDate: new Date(),
+    sortOrder: sequence,
+  })
+)
+
+export const DbOfferApplicantFactory = Factory.define<DbOfferApplicant>(
   ({ sequence }) => ({
     id: sequence,
     listingId: 1,

--- a/src/services/lease-service/tests/factories/offer-applicant.ts
+++ b/src/services/lease-service/tests/factories/offer-applicant.ts
@@ -1,7 +1,8 @@
 import { Factory } from 'fishery'
 import { ApplicantStatus, LeaseStatus } from 'onecore-types'
 // TODO: import from onecore-types
-import { DbOfferApplicant, OfferApplicant } from '../../adapters/offer-adapter'
+import { OfferApplicant } from '../../adapters/offer-adapter'
+import { DbOfferApplicant } from '../../adapters/types'
 
 export const OfferApplicantFactory = Factory.define<OfferApplicant>(
   ({ sequence }) => ({

--- a/src/services/lease-service/tests/factories/offer-applicant.ts
+++ b/src/services/lease-service/tests/factories/offer-applicant.ts
@@ -1,0 +1,22 @@
+import { Factory } from 'fishery'
+import { ApplicantStatus, LeaseStatus } from 'onecore-types'
+// TODO: import from onecore-types
+import { OfferApplicant } from '../../adapters/offer-adapter'
+
+export const OfferApplicantFactory = Factory.define<OfferApplicant>(
+  ({ sequence }) => ({
+    id: sequence,
+    listingId: 1,
+    offerId: 1,
+    applicantId: 1,
+    applicantPriority: 1,
+    applicantQueuePoints: 1,
+    applicantStatus: ApplicantStatus.Active,
+    applicantAddress: 'Testgatan 14',
+    applicantApplicationType: 'Additional',
+    applicantHasParkingSpace: true,
+    applicantHousingLeaseStatus: LeaseStatus.Current,
+    createdAt: new Date(),
+    sortOrder: sequence,
+  })
+)

--- a/src/services/lease-service/tests/offer-service.test.ts
+++ b/src/services/lease-service/tests/offer-service.test.ts
@@ -44,7 +44,9 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [],
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
       expiresAt: new Date(),
     })
 
@@ -78,7 +80,9 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [],
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
       expiresAt: new Date(),
     })
 
@@ -116,7 +120,9 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [],
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
       expiresAt: new Date(),
     })
 
@@ -240,111 +246,166 @@ describe('acceptOffer', () => {
   })
 })
 
-// describe('denyOffer', () => {
-//   it('returns gracefully if offer update fails', async () => {
-//     const updateOfferStatusSpy = jest.spyOn(offerAdapter, 'updateOfferStatus')
-//
-//     updateOfferStatusSpy.mockResolvedValueOnce({ ok: false, err: 'unknown' })
-//
-//     const listing = await listingAdapter.createListing(
-//       factory.listing.build({ status: ListingStatus.Expired })
-//     )
-//     assert(listing.ok)
-//     const applicant = await listingAdapter.createApplication(
-//       factory.applicant.build({ listingId: listing.data.id })
-//     )
-//
-//     const offer = await offerAdapter.create({
-//       status: OfferStatus.Active,
-//       listingId: listing.data.id,
-//       applicantId: applicant.id,
-//       offerApplicants: [],
-//       expiresAt: new Date(),
-//     })
-//
-//     const res = await service.denyOffer({
-//       applicantId: applicant.id,
-//       offerId: offer.id,
-//     })
-//
-//     expect(updateOfferStatusSpy).toHaveBeenCalled()
-//     expect(res).toEqual({ ok: false, err: 'update-offer' })
-//   })
-//
-//   it('rollbacks applicant status change if update offer fails', async () => {
-//     const updateOfferStatusSpy = jest.spyOn(offerAdapter, 'updateOfferStatus')
-//
-//     const listing = await listingAdapter.createListing(
-//       factory.listing.build({ status: ListingStatus.Expired })
-//     )
-//     assert(listing.ok)
-//     const applicant = await listingAdapter.createApplication(
-//       factory.applicant.build({ listingId: listing.data.id })
-//     )
-//
-//     const offer = await offerAdapter.create({
-//       status: OfferStatus.Active,
-//       listingId: listing.data.id,
-//       applicantId: applicant.id,
-//       offerApplicants: [],
-//       expiresAt: new Date(),
-//     })
-//
-//     updateOfferStatusSpy.mockResolvedValueOnce({ ok: false, err: 'unknown' })
-//     const res = await service.denyOffer({
-//       applicantId: applicant.id,
-//       offerId: offer.id,
-//     })
-//
-//     expect(updateOfferStatusSpy).toHaveBeenCalled()
-//     expect(res).toEqual({ ok: false, err: 'update-offer' })
-//
-//     const applicantFromDb = await listingAdapter.getApplicantById(
-//       listing.data.id
-//     )
-//     expect(applicantFromDb?.status).toBe(applicant.status)
-//   })
-//
-//   it('updates applicant and offer', async () => {
-//     const updateApplicantStatusSpy = jest.spyOn(
-//       listingAdapter,
-//       'updateApplicantStatus'
-//     )
-//
-//     const updateOfferSpy = jest.spyOn(offerAdapter, 'updateOfferStatus')
-//     const listing = await listingAdapter.createListing(
-//       factory.listing.build({ status: ListingStatus.Expired })
-//     )
-//     assert(listing.ok)
-//     const applicant = await listingAdapter.createApplication(
-//       factory.applicant.build({ listingId: listing.data.id })
-//     )
-//
-//     const offer = await offerAdapter.create(db, {
-//       status: OfferStatus.Active,
-//       listingId: listing.data.id,
-//       applicantId: applicant.id,
-//       offerApplicants: [],
-//       expiresAt: new Date(),
-//     })
-//
-//     assert(offer.ok)
-//
-//     const res = await service.denyOffer({
-//       applicantId: applicant.id,
-//       offerId: offer.data.id,
-//     })
-//
-//     expect(updateApplicantStatusSpy).toHaveBeenCalled()
-//     expect(updateOfferSpy).toHaveBeenCalled()
-//     expect(res).toEqual({ ok: true, data: null })
-//
-//     const updatedApplicant = await listingAdapter.getApplicantById(applicant.id)
-//     const updatedOffer = await offerAdapter.getOfferByOfferId(offer.id)
-//     assert(updatedOffer.ok)
-//
-//     expect(updatedApplicant?.status).toBe(ApplicantStatus.WithdrawnByUser)
-//     // TODO: Offer status is incorrectly a string because of db column type!!
-//     expect(Number(updatedOffer.data.status)).toBe(OfferStatus.Declined)
-//   })
-// })
+describe('denyOffer', () => {
+  it('returns gracefully if offer update fails', async () => {
+    const updateOfferStatusSpy = jest.spyOn(offerAdapter, 'updateOfferStatus')
+
+    updateOfferStatusSpy.mockResolvedValueOnce({ ok: false, err: 'unknown' })
+
+    const listing = await listingAdapter.createListing(
+      factory.listing.build({ status: ListingStatus.Expired })
+    )
+    assert(listing.ok)
+    const applicant = await listingAdapter.createApplication(
+      factory.applicant.build({ listingId: listing.data.id })
+    )
+
+    const offer = await offerAdapter.create(db, {
+      status: OfferStatus.Active,
+      listingId: listing.data.id,
+      applicantId: applicant.id,
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
+      expiresAt: new Date(),
+    })
+    assert(offer.ok)
+
+    const res = await service.denyOffer({
+      applicantId: applicant.id,
+      offerId: offer.data.id,
+      listingId: listing.data.id,
+    })
+
+    expect(updateOfferStatusSpy).toHaveBeenCalled()
+    expect(res).toEqual({ ok: false, err: 'update-offer' })
+  })
+
+  it('rollbacks applicant status change if update offer fails', async () => {
+    const updateOfferStatusSpy = jest.spyOn(offerAdapter, 'updateOfferStatus')
+
+    const listing = await listingAdapter.createListing(
+      factory.listing.build({ status: ListingStatus.Expired })
+    )
+    assert(listing.ok)
+    const applicant = await listingAdapter.createApplication(
+      factory.applicant.build({ listingId: listing.data.id })
+    )
+
+    const offer = await offerAdapter.create(db, {
+      status: OfferStatus.Active,
+      listingId: listing.data.id,
+      applicantId: applicant.id,
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
+      expiresAt: new Date(),
+    })
+
+    assert(offer.ok)
+    updateOfferStatusSpy.mockResolvedValueOnce({ ok: false, err: 'unknown' })
+    const res = await service.denyOffer({
+      applicantId: applicant.id,
+      offerId: offer.data.id,
+      listingId: listing.data.id,
+    })
+
+    expect(updateOfferStatusSpy).toHaveBeenCalled()
+    expect(res).toEqual({ ok: false, err: 'update-offer' })
+
+    const applicantFromDb = await listingAdapter.getApplicantById(
+      listing.data.id
+    )
+    expect(applicantFromDb?.status).toBe(applicant.status)
+  })
+
+  it('updates applicant and offer', async () => {
+    const updateApplicantStatusSpy = jest.spyOn(
+      listingAdapter,
+      'updateApplicantStatus'
+    )
+
+    const updateOfferSpy = jest.spyOn(offerAdapter, 'updateOfferStatus')
+    const listing = await listingAdapter.createListing(
+      factory.listing.build({ status: ListingStatus.Expired })
+    )
+    assert(listing.ok)
+    const applicant = await listingAdapter.createApplication(
+      factory.applicant.build({ listingId: listing.data.id })
+    )
+
+    const offer = await offerAdapter.create(db, {
+      status: OfferStatus.Active,
+      listingId: listing.data.id,
+      applicantId: applicant.id,
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
+      expiresAt: new Date(),
+    })
+
+    assert(offer.ok)
+
+    const res = await service.denyOffer({
+      applicantId: applicant.id,
+      offerId: offer.data.id,
+      listingId: listing.data.id,
+    })
+
+    expect(updateApplicantStatusSpy).toHaveBeenCalled()
+    expect(updateOfferSpy).toHaveBeenCalled()
+    expect(res).toEqual({ ok: true, data: null })
+
+    const updatedApplicant = await listingAdapter.getApplicantById(applicant.id)
+    const updatedOffer = await offerAdapter.getOfferByOfferId(offer.data.id)
+    assert(updatedOffer.ok)
+
+    expect(updatedApplicant?.status).toBe(ApplicantStatus.WithdrawnByUser)
+    // TODO: Offer status is incorrectly a string because of db column type!!
+    expect(Number(updatedOffer.data.status)).toBe(OfferStatus.Declined)
+  })
+
+  it('updates offerApplicants', async () => {
+    const listing = await listingAdapter.createListing(
+      factory.listing.build({ status: ListingStatus.Expired })
+    )
+    assert(listing.ok)
+    const applicant = await listingAdapter.createApplication(
+      factory.applicant.build({ listingId: listing.data.id })
+    )
+
+    const initialApplicantStatus = ApplicantStatus.Active
+    const offeredApplicant = factory.dbOfferApplicant.build({
+      applicantStatus: initialApplicantStatus,
+      applicantId: applicant.id,
+    })
+    const offer = await offerAdapter.create(db, {
+      status: OfferStatus.Active,
+      listingId: listing.data.id,
+      applicantId: applicant.id,
+      offerApplicants: [offeredApplicant],
+      expiresAt: new Date(),
+    })
+
+    assert(offer.ok)
+
+    const offeredApplicantInDbBeforeAccept = await db('offer_applicant')
+
+    expect(offeredApplicantInDbBeforeAccept[0].applicantStatus).toEqual(
+      initialApplicantStatus
+    )
+
+    const res = await service.denyOffer({
+      applicantId: applicant.id,
+      listingId: listing.data.id,
+      offerId: offer.data.id,
+    })
+
+    expect(res.ok).toBe(true)
+    const offeredApplicantInDbAfterAccept = await db('offer_applicant')
+
+    expect(offeredApplicantInDbAfterAccept[0].applicantStatus).toEqual(
+      ApplicantStatus.OfferDeclined
+    )
+  })
+})

--- a/src/services/lease-service/tests/offer-service.test.ts
+++ b/src/services/lease-service/tests/offer-service.test.ts
@@ -201,7 +201,7 @@ describe('acceptOffer', () => {
     expect(Number(updatedOffer.data.status)).toBe(OfferStatus.Accepted)
   })
 
-  it('updates selectedApplicants', async () => {
+  it('updates offer applicant', async () => {
     const listing = await listingAdapter.createListing(
       factory.listing.build({ status: ListingStatus.Expired })
     )
@@ -225,9 +225,9 @@ describe('acceptOffer', () => {
 
     assert(offer.ok)
 
-    const offeredApplicantInDbBeforeAccept = await db('offer_applicant')
+    const [offerApplicantInDbBeforeAccept] = await db('offer_applicant')
 
-    expect(offeredApplicantInDbBeforeAccept[0].applicantStatus).toEqual(
+    expect(offerApplicantInDbBeforeAccept.applicantStatus).toEqual(
       initialApplicantStatus
     )
 
@@ -238,9 +238,9 @@ describe('acceptOffer', () => {
     })
 
     expect(res.ok).toBe(true)
-    const offeredApplicantInDbAfterAccept = await db('offer_applicant')
+    const [offerApplicantInDbAfterAccept] = await db('offer_applicant')
 
-    expect(offeredApplicantInDbAfterAccept[0].applicantStatus).toEqual(
+    expect(offerApplicantInDbAfterAccept.applicantStatus).toEqual(
       ApplicantStatus.OfferAccepted
     )
   })
@@ -364,7 +364,7 @@ describe('denyOffer', () => {
     expect(updatedOffer.data.status).toBe(OfferStatus.Declined)
   })
 
-  it('updates offer_applicant', async () => {
+  it('updates offer applicant', async () => {
     const listing = await listingAdapter.createListing(
       factory.listing.build({ status: ListingStatus.Expired })
     )
@@ -388,9 +388,9 @@ describe('denyOffer', () => {
 
     assert(offer.ok)
 
-    const offeredApplicantInDbBeforeAccept = await db('offer_applicant')
+    const [offerApplicantInDbBeforeAccept] = await db('offer_applicant')
 
-    expect(offeredApplicantInDbBeforeAccept[0].applicantStatus).toEqual(
+    expect(offerApplicantInDbBeforeAccept.applicantStatus).toEqual(
       initialApplicantStatus
     )
 
@@ -401,9 +401,9 @@ describe('denyOffer', () => {
     })
 
     expect(res.ok).toBe(true)
-    const offeredApplicantInDbAfterAccept = await db('offer_applicant')
+    const [offerApplicantInDbAfterAccept] = await db('offer_applicant')
 
-    expect(offeredApplicantInDbAfterAccept[0].applicantStatus).toEqual(
+    expect(offerApplicantInDbAfterAccept.applicantStatus).toEqual(
       ApplicantStatus.OfferDeclined
     )
   })

--- a/src/services/lease-service/tests/offer-service.test.ts
+++ b/src/services/lease-service/tests/offer-service.test.ts
@@ -7,15 +7,20 @@ import * as offerAdapter from '../adapters/offer-adapter'
 import { db, migrate, teardown } from '../adapters/db'
 import * as service from '../offer-service'
 
-beforeAll(migrate)
+beforeAll(async () => {
+  await migrate()
+})
 
 beforeEach(async () => {
+  await db('offer_applicant').del()
   await db('offer').del()
   await db('applicant').del()
   await db('listing').del()
 })
 
-afterAll(teardown)
+afterAll(async () => {
+  await teardown()
+})
 
 afterEach(jest.restoreAllMocks)
 
@@ -158,7 +163,9 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [],
+      offerApplicants: [
+        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+      ],
       expiresAt: new Date(),
     })
 
@@ -200,6 +207,7 @@ describe('acceptOffer', () => {
     const initialApplicantStatus = ApplicantStatus.Active
     const offeredApplicant = factory.dbOfferApplicant.build({
       applicantStatus: initialApplicantStatus,
+      applicantId: applicant.id,
     })
     const offer = await offerAdapter.create(db, {
       status: OfferStatus.Active,

--- a/src/services/lease-service/tests/offer-service.test.ts
+++ b/src/services/lease-service/tests/offer-service.test.ts
@@ -45,7 +45,7 @@ describe('acceptOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -81,7 +81,7 @@ describe('acceptOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -121,7 +121,7 @@ describe('acceptOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -170,7 +170,7 @@ describe('acceptOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -211,8 +211,8 @@ describe('acceptOffer', () => {
     )
 
     const initialApplicantStatus = ApplicantStatus.Active
-    const offeredApplicant = factory.dbOfferApplicant.build({
-      applicantStatus: initialApplicantStatus,
+    const offeredApplicant = factory.offerApplicant.build({
+      status: initialApplicantStatus,
       applicantId: applicant.id,
     })
     const offer = await offerAdapter.create(db, {
@@ -265,7 +265,7 @@ describe('denyOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -297,7 +297,7 @@ describe('denyOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -339,7 +339,7 @@ describe('denyOffer', () => {
       listingId: listing.data.id,
       applicantId: applicant.id,
       selectedApplicants: [
-        factory.dbOfferApplicant.build({ applicantId: applicant.id }),
+        factory.offerApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
     })
@@ -360,9 +360,8 @@ describe('denyOffer', () => {
     const updatedOffer = await offerAdapter.getOfferByOfferId(offer.data.id)
     assert(updatedOffer.ok)
 
-    expect(updatedApplicant?.status).toBe(ApplicantStatus.WithdrawnByUser)
-    // TODO: Offer status is incorrectly a string because of db column type!!
-    expect(Number(updatedOffer.data.status)).toBe(OfferStatus.Declined)
+    expect(updatedApplicant?.status).toBe(ApplicantStatus.OfferDeclined)
+    expect(updatedOffer.data.status).toBe(OfferStatus.Declined)
   })
 
   it('updates offer_applicant', async () => {
@@ -375,8 +374,8 @@ describe('denyOffer', () => {
     )
 
     const initialApplicantStatus = ApplicantStatus.Active
-    const offeredApplicant = factory.dbOfferApplicant.build({
-      applicantStatus: initialApplicantStatus,
+    const offeredApplicant = factory.offerApplicant.build({
+      status: initialApplicantStatus,
       applicantId: applicant.id,
     })
     const offer = await offerAdapter.create(db, {

--- a/src/services/lease-service/tests/offer-service.test.ts
+++ b/src/services/lease-service/tests/offer-service.test.ts
@@ -44,7 +44,7 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -80,7 +80,7 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -120,7 +120,7 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -169,7 +169,7 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -201,7 +201,7 @@ describe('acceptOffer', () => {
     expect(Number(updatedOffer.data.status)).toBe(OfferStatus.Accepted)
   })
 
-  it('updates offerApplicants', async () => {
+  it('updates selectedApplicants', async () => {
     const listing = await listingAdapter.createListing(
       factory.listing.build({ status: ListingStatus.Expired })
     )
@@ -219,7 +219,7 @@ describe('acceptOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [offeredApplicant],
+      selectedApplicants: [offeredApplicant],
       expiresAt: new Date(),
     })
 
@@ -264,7 +264,7 @@ describe('denyOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -296,7 +296,7 @@ describe('denyOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -338,7 +338,7 @@ describe('denyOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [
+      selectedApplicants: [
         factory.dbOfferApplicant.build({ applicantId: applicant.id }),
       ],
       expiresAt: new Date(),
@@ -365,7 +365,7 @@ describe('denyOffer', () => {
     expect(Number(updatedOffer.data.status)).toBe(OfferStatus.Declined)
   })
 
-  it('updates offerApplicants', async () => {
+  it('updates offer_applicant', async () => {
     const listing = await listingAdapter.createListing(
       factory.listing.build({ status: ListingStatus.Expired })
     )
@@ -383,7 +383,7 @@ describe('denyOffer', () => {
       status: OfferStatus.Active,
       listingId: listing.data.id,
       applicantId: applicant.id,
-      offerApplicants: [offeredApplicant],
+      selectedApplicants: [offeredApplicant],
       expiresAt: new Date(),
     })
 

--- a/src/services/lease-service/tests/routes/offers.test.ts
+++ b/src/services/lease-service/tests/routes/offers.test.ts
@@ -69,7 +69,6 @@ describe('offers', () => {
       }
 
       expect(res.status).toBe(201)
-      console.log(res.body)
       expect(res.body.content.createdAt).toBeDefined()
       expect(res.body.content.listingId).toEqual(expected.listingId)
       expect(res.body.content.expiresAt).toEqual(expected.expiresAt)

--- a/src/services/lease-service/tests/routes/offers.test.ts
+++ b/src/services/lease-service/tests/routes/offers.test.ts
@@ -28,7 +28,7 @@ describe('offers', () => {
         status: 'foo',
         listingId: 1,
         applicantId: 1,
-        selectedApplicants: [],
+        selectedApplicants: [factory.offerApplicant.build({ applicantId: 1 })],
         expiresAt: new Date().toISOString(),
       }
 
@@ -57,7 +57,7 @@ describe('offers', () => {
         status: OfferStatus.Active,
         listingId: 1,
         applicantId: 1,
-        selectedApplicants: [],
+        selectedApplicants: [factory.offerApplicant.build({ applicantId: 1 })],
         expiresAt: new Date().toISOString(),
       }
 
@@ -89,7 +89,7 @@ describe('offers', () => {
         status: OfferStatus.Active,
         listingId: 1,
         applicantId: 1,
-        selectedApplicants: [],
+        selectedApplicants: [factory.offerApplicant.build({ applicantId: 1 })],
         expiresAt: new Date().toISOString(),
       }
       const resSubsequentOffer = await request(app.callback())
@@ -115,7 +115,7 @@ describe('offers', () => {
         status: OfferStatus.Active,
         listingId: 1,
         applicantId: 1,
-        selectedApplicants: [],
+        selectedApplicants: [factory.offerApplicant.build({ applicantId: 1 })],
         expiresAt: new Date().toISOString(),
       }
       const resSubsequentOffer = await request(app.callback())

--- a/src/services/lease-service/tests/routes/offers.test.ts
+++ b/src/services/lease-service/tests/routes/offers.test.ts
@@ -47,7 +47,7 @@ describe('offers', () => {
       const offer = { ...tempOffer, selectedApplicants: [] }
 
       jest
-        .spyOn(offerAdapter, 'getOffersByListingId')
+        .spyOn(offerAdapter, 'getOffersWithOfferApplicantsByListingId')
         .mockResolvedValueOnce({ ok: true, data: [] })
       jest
         .spyOn(offerAdapter, 'create')
@@ -78,7 +78,7 @@ describe('offers', () => {
       const tempOffer = factory.offer.build()
       const offer = { ...tempOffer, selectedApplicants: [] }
       jest
-        .spyOn(offerAdapter, 'getOffersByListingId')
+        .spyOn(offerAdapter, 'getOffersWithOfferApplicantsByListingId')
         .mockResolvedValueOnce({ ok: true, data: [offer] })
       jest
         .spyOn(offerAdapter, 'create')
@@ -104,7 +104,7 @@ describe('offers', () => {
       const tempOffer = factory.offer.build({ status: OfferStatus.Declined })
       const offer = { ...tempOffer, selectedApplicants: [] }
       jest
-        .spyOn(offerAdapter, 'getOffersByListingId')
+        .spyOn(offerAdapter, 'getOffersWithOfferApplicantsByListingId')
         .mockResolvedValueOnce({ ok: true, data: [offer] })
       jest
         .spyOn(offerAdapter, 'create')
@@ -336,7 +336,7 @@ describe('offers', () => {
       const offer = { ...tempOffer, selectedApplicants: [] }
 
       jest
-        .spyOn(offerAdapter, 'getOffersByListingId')
+        .spyOn(offerAdapter, 'getOffersWithOfferApplicantsByListingId')
         .mockResolvedValueOnce({ ok: true, data: [offer] })
 
       const res = await request(app.callback()).get(`/offers/listing-id/1`)
@@ -351,7 +351,7 @@ describe('offers', () => {
 
     it('should respond with an error if get offers fails', async () => {
       jest
-        .spyOn(offerAdapter, 'getOffersByListingId')
+        .spyOn(offerAdapter, 'getOffersWithOfferApplicantsByListingId')
         .mockResolvedValueOnce({ ok: false, err: 'unknown' })
 
       const res = await request(app.callback()).get(`/offers/listing-id/1`)


### PR DESCRIPTION
Replace offer "SelectionSnapshot" with "offer_applicants" junction table.
This table lets us holds relevant applicant information over multiple "offer rounds".

This migration will be "irreversible" in the sense that we "can't" restore Offer.SelectionSnapshot since it used snapshotted xpand data.