### PR TITLE
MIM-18: Applicant and parking space estate code diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "strong-soap": "^4.1.4",
         "swagger-jsdoc": "^6.2.8",
         "tedious": "^18.2.4",
+        "ts-pattern": "^5.4.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -9695,6 +9696,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.4.0.tgz",
+      "integrity": "sha512-hgfOMfjlrARCnYtGD/xEAkFHDXuSyuqjzFSltyQCbN689uNvoQL20TVN2XFcLMjfNuwSsQGU+xtH6MrjIwhwUg==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "strong-soap": "^4.1.4",
     "swagger-jsdoc": "^6.2.8",
     "tedious": "^18.2.4",
+    "ts-pattern": "^5.4.0",
     "zod": "^3.23.8"
   }
 }

--- a/src/services/lease-service/property-rental-rules-validator.ts
+++ b/src/services/lease-service/property-rental-rules-validator.ts
@@ -1,46 +1,46 @@
-import { Tenant } from 'onecore-types'
+import { Lease } from 'onecore-types'
+import { match, P } from 'ts-pattern'
+
 import { getEstateCodeFromXpandByRentalObjectCode } from './adapters/xpand/estate-code-adapter'
 
-const propertiesWithSpecificRentalRules = [
-  {
-    estateCode: '24104', //Sjöodjuret 2
-  },
-  {
-    estateCode: '23002', //ROTORN 13
-  },
-  {
-    estateCode: '23003', //ISOLATORN 14
-  },
-]
-
-const doesPropertyBelongingToParkingSpaceHaveSpecificRentalRules = (
-  estateCode: string
-) => {
-  return propertiesWithSpecificRentalRules.some(
-    (property) => estateCode == property.estateCode
-  )
+export const PROPERTIES_WITH_SPECIFIC_RENTAL_RULES = {
+  SJOODJURET_2: '24104',
+  ROTORN_13: '23002',
+  ROTORN_14: '23001',
+  ISOLATORN_14: '23003',
 }
 
-async function doesTenantHaveHousingContractInSamePropertyAsListing(
-  data: Pick<Tenant, 'currentHousingContract' | 'upcomingHousingContract'>,
+const parkingSpaceNeedsValidation = (estateCode: string) =>
+  Object.values(PROPERTIES_WITH_SPECIFIC_RENTAL_RULES).includes(estateCode)
+
+async function isParkingSpaceRentableForTenant(
+  lease: Lease,
   listingEstateCode: string
-): Promise<boolean> {
-  const propertyInfo = data.upcomingHousingContract
-    ? await getEstateCodeFromXpandByRentalObjectCode(
-        data.upcomingHousingContract.rentalPropertyId
-      )
-    : data.currentHousingContract
-      ? await getEstateCodeFromXpandByRentalObjectCode(
-          data.currentHousingContract.rentalPropertyId
-        )
-      : undefined
+) {
+  const propertyInfo = await getEstateCodeFromXpandByRentalObjectCode(
+    lease.rentalPropertyId
+  )
 
   if (!propertyInfo) return false
 
-  return propertyInfo.estateCode === listingEstateCode
+  /**
+   * ROTORN 13 and ROTORN 14 are considered the same property
+   * in the context of rental rules.
+   *
+   * So we need to check if both the listing estate code and
+   * property estate code are either ROTORN 13 or ROTORN 14.
+   * If they are, we can consider them the same property.
+   *
+   * Otherwise we expect them to be the same.
+   */
+  const { ROTORN_13, ROTORN_14 } = PROPERTIES_WITH_SPECIFIC_RENTAL_RULES
+
+  return match([listingEstateCode, propertyInfo.estateCode])
+    .with(
+      [P.union(ROTORN_13, ROTORN_14), P.union(ROTORN_13, ROTORN_14)],
+      () => true
+    )
+    .otherwise(([a, b]) => a === b)
 }
 
-export {
-  doesPropertyBelongingToParkingSpaceHaveSpecificRentalRules,
-  doesTenantHaveHousingContractInSamePropertyAsListing,
-}
+export { parkingSpaceNeedsValidation, isParkingSpaceRentableForTenant }


### PR DESCRIPTION
When validating property rental rules there is a specific case for "ROTORN 13" and "ROTORN 14" and their corresponding estate codes.

If tenant property and parking space property is either of these, tenant can apply for property, otherwise they need to be the same (like before)

I didn't find a satisfying way to add this special case to the existing code so I rewrote the implementation into what I think conveys the more generic intent that this special case adds to the equation.

- I added one of my favourite tools `ts-pattern` which is a pattern matching library for TS. It's not absolutely needed and it has a bit of a learning curve (like many libraries) but it enables more streamlined and logical pattern matching that is easy to follow IMO.

`ts-pattern` is like native `switch` on steroids.
This is how it's used in the code now:
```ts
  return match([listingEstateCode, propertyInfo.estateCode])
    .with(
      [P.union(ROTORN_13, ROTORN_14), P.union(ROTORN_13, ROTORN_14)],
      () => true
    )
    .otherwise(([a, b]) => a === b)
```
  We `match` on a tuple of both the estate codes.
If the first in the tuple is either "ROTORN_13" or "ROTORN_14" and the second one is also either "ROTORN_13" or "ROTORN_14", we return true, otherwise we check if estate codes `a` and `b` are equal.

- Rename `doesTenantHaveHousingContractInSamePropertyAsListing` to `isParkingSpaceRentableForTenant`
  I think the former name doesn't fit as well when there now are cases where that per definition is not true, as with ROTORN. So I thought `isParkingSpaceRentableForTenant` is a bit less specific, which we need now when a === b isn't the only check we do anymore.
