### PR TITLE
MIM-157: Filter listings with applicants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7549,16 +7549,10 @@
       }
     },
     "node_modules/onecore-types": {
-<<<<<<< HEAD
-      "version": "1.30.3",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.30.3.tgz",
-      "integrity": "sha512-DvuzZNDUiP3P/BTfYnxwodYQBW7j0Z3PX4Fi6uZZSGC0TvBe3+gqyxvVhyT3VTIjJWEG+Umuqt5a8/zB6SsTjA==",
-=======
       "version": "1.31.0",
       "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.31.0.tgz",
       "integrity": "sha512-9MFoOW78gfylIfEOHJqw/RkbL8Q6526dnLBoZcgav8yC69X9Ef6ufvIZMxO4k69HmbmbiNb7QbA0o5JPnG43jQ==",
       "license": "ISC",
->>>>>>> 19e841e (bump onecore-types)
       "dependencies": {
         "release-please": "^16.8.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa2-swagger-ui": "^5.10.0",
         "mssql": "^11.0.1",
-        "onecore-types": "^1.30.1 ",
+        "onecore-types": "^1.31.0",
         "onecore-utilities": "^1.1.0",
         "personnummer": "^3.2.1",
         "pino": "^9.1.0",
@@ -7549,9 +7549,16 @@
       }
     },
     "node_modules/onecore-types": {
+<<<<<<< HEAD
       "version": "1.30.3",
       "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.30.3.tgz",
       "integrity": "sha512-DvuzZNDUiP3P/BTfYnxwodYQBW7j0Z3PX4Fi6uZZSGC0TvBe3+gqyxvVhyT3VTIjJWEG+Umuqt5a8/zB6SsTjA==",
+=======
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.31.0.tgz",
+      "integrity": "sha512-9MFoOW78gfylIfEOHJqw/RkbL8Q6526dnLBoZcgav8yC69X9Ef6ufvIZMxO4k69HmbmbiNb7QbA0o5JPnG43jQ==",
+      "license": "ISC",
+>>>>>>> 19e841e (bump onecore-types)
       "dependencies": {
         "release-please": "^16.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa2-swagger-ui": "^5.10.0",
     "mssql": "^11.0.1",
-    "onecore-types": "^1.30.1 ",
+    "onecore-types": "^1.31.0",
     "onecore-utilities": "^1.1.0",
     "personnummer": "^3.2.1",
     "pino": "^9.1.0",

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -250,14 +250,14 @@ const updateApplicantStatus = async (
 }
 
 type GetListingsWithApplicantsFilter = {
-  type: 'published' | 'ready-for-offer' | 'offered' | 'historical'
+  by?: { type?: 'published' | 'ready-for-offer' | 'offered' | 'historical' }
 }
 
 const getListingsWithApplicants = async (
-  filter?: GetListingsWithApplicantsFilter
+  opts?: GetListingsWithApplicantsFilter
 ): Promise<AdapterResult<Array<Listing>, 'unknown'>> => {
   try {
-    const whereClause = match(filter)
+    const whereClause = match(opts?.by)
       .with({ type: 'published' }, () =>
         db.raw('WHERE l.Status = ?', [ListingStatus.Active])
       )

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -319,17 +319,16 @@ const getListingsWithApplicants = async (
     })
 
     const result = await listings.then((rows) =>
-      rows.map((row) => {
-        return transformListing({
+      rows.map((row) =>
+        transformListing({
           ...row,
           applicants: parseApplicantsJson(row.applicants),
         })
-      })
+      )
     )
 
     return { ok: true, data: result }
   } catch (err) {
-    console.log(err)
     logger.error(err, 'listingAdapter.getListingsWithApplicants')
     return { ok: false, err: 'unknown' }
   }

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -4,6 +4,7 @@ import {
   Listing,
   ApplicantStatus,
   ListingStatus,
+  GetListingsWithApplicantsFilterParams,
 } from 'onecore-types'
 import { RequestError } from 'tedious'
 import { Knex } from 'knex'
@@ -249,12 +250,8 @@ const updateApplicantStatus = async (
   }
 }
 
-type GetListingsWithApplicantsFilter = {
-  by?: { type?: 'published' | 'ready-for-offer' | 'offered' | 'historical' }
-}
-
 const getListingsWithApplicants = async (
-  opts?: GetListingsWithApplicantsFilter
+  opts?: GetListingsWithApplicantsFilterParams
 ): Promise<AdapterResult<Array<Listing>, 'unknown'>> => {
   try {
     const whereClause = match(opts?.by)

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -405,7 +405,7 @@ export const routes = (router: KoaRouter) => {
     const metadata = generateRouteMetadata(ctx)
     try {
       const listingsWithApplicants =
-        await listingAdapter.getAllListingsWithApplicants()
+        await listingAdapter.getListingsWithApplicants()
       ctx.status = 200
       ctx.body = { content: listingsWithApplicants, ...metadata }
     } catch (error) {

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -436,7 +436,7 @@ export const routes = (router: KoaRouter) => {
     }
 
     ctx.status = 200
-    ctx.body = { content: listingsWithApplicants, ...metadata }
+    ctx.body = { content: listingsWithApplicants.data, ...metadata }
   })
 
   router.post('/listings/sync-internal-from-xpand', async (ctx) => {

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -7,6 +7,7 @@ import {
 } from 'onecore-types'
 import { z } from 'zod'
 import { generateRouteMetadata, logger } from 'onecore-utilities'
+import { match, P } from 'ts-pattern'
 
 import { parseRequestBody } from '../../../middlewares/parse-request-body'
 import * as priorityListService from '../priority-list-service'
@@ -360,9 +361,17 @@ export const routes = (router: KoaRouter) => {
    * /listings-with-applicants:
    *   get:
    *     summary: Get listings with applicants
-   *     description: Fetches all listings that have associated applicants.
+   *     description: Fetches all listings with their associated applicants.
    *     tags:
    *       - Listings
+   *     parameters:
+   *       - in: query
+   *         name: type
+   *         required: false
+   *         schema:
+   *           type: string
+   *           enum: [published, ready-for-offer, offered, historical]
+   *         description: Filters listings by one of the above types. Must be one of the specified values.
    *     responses:
    *       '200':
    *         description: Successfully retrieved listings with applicants.
@@ -403,19 +412,31 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('/listings-with-applicants', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    try {
-      const listingsWithApplicants =
-        await listingAdapter.getListingsWithApplicants()
-      ctx.status = 200
-      ctx.body = { content: listingsWithApplicants, ...metadata }
-    } catch (error) {
-      logger.error(error, 'Error fetching listings with applicants:')
-      ctx.status = 500 // Internal Server Error
+    const opts = match(ctx.query.type)
+      .with(
+        P.union('published', 'ready-for-offer', 'offered', 'historical'),
+        (type) => ({ by: { type } })
+      )
+      .otherwise(() => undefined)
+
+    const listingsWithApplicants =
+      await listingAdapter.getListingsWithApplicants(opts)
+
+    if (!listingsWithApplicants.ok) {
+      logger.error(
+        listingsWithApplicants.err,
+        'Error fetching listings with applicants:'
+      )
+      ctx.status = 500
       ctx.body = {
         error: 'An error occurred while fetching listings with applicants.',
         ...metadata,
       }
+      return
     }
+
+    ctx.status = 200
+    ctx.body = { content: listingsWithApplicants, ...metadata }
   })
 
   router.post('/listings/sync-internal-from-xpand', async (ctx) => {

--- a/src/services/lease-service/tests/adapters/listing-adapter/delete-listing.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/delete-listing.test.ts
@@ -49,10 +49,10 @@ describe(listingAdapter.deleteListing, () => {
     assert(listing_2.ok)
 
     const deletion = await listingAdapter.deleteListing(listing_1.data.id)
-    const remainingListings =
-      await listingAdapter.getAllListingsWithApplicants()
+    const remainingListings = await listingAdapter.getListingsWithApplicants()
+    assert(remainingListings.ok)
 
     expect(deletion).toMatchObject({ ok: true })
-    expect(remainingListings).toHaveLength(1)
+    expect(remainingListings.data).toHaveLength(1)
   })
 })

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -1,0 +1,198 @@
+import assert from 'node:assert'
+import { ListingStatus, OfferStatus } from 'onecore-types'
+
+import { db, migrate, teardown } from '../../../adapters/db'
+import * as listingAdapter from '../../../adapters/listing-adapter'
+import * as offerAdapter from '../../../adapters/offer-adapter'
+import * as factory from './../../factories'
+
+beforeAll(async () => {
+  await migrate()
+})
+
+afterEach(async () => {
+  await db('offer_applicant').del()
+  await db('offer').del()
+  await db('applicant').del()
+  await db('listing').del()
+})
+
+afterAll(async () => {
+  await teardown()
+})
+
+describe(listingAdapter.getListingsWithApplicants, () => {
+  it('returns a formatted list of listings and corresponding applicants', async () => {
+    const listing1 = await listingAdapter.createListing(
+      factory.listing.build({ rentalObjectCode: '1' })
+    )
+    const listing2 = await listingAdapter.createListing(
+      factory.listing.build({ rentalObjectCode: '2' })
+    )
+    assert(listing1.ok)
+    assert(listing2.ok)
+    await listingAdapter.createApplication(
+      factory.applicant.build({ listingId: listing1.data.id })
+    )
+    await listingAdapter.createApplication(
+      factory.applicant.build({ listingId: listing2.data.id })
+    )
+    const listings = await listingAdapter.getListingsWithApplicants()
+    assert(listings.ok)
+    const [fst, snd] = listings.data
+
+    expect(fst.applicants).toHaveLength(1)
+    expect(fst.applicants?.[0]?.listingId).toBe(fst.id)
+
+    expect(snd.applicants).toHaveLength(1)
+    expect(snd.applicants?.[0]?.listingId).toBe(snd.id)
+  })
+
+  describe('filtering', () => {
+    it('only gets published listings', async () => {
+      const publishedListing = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Active,
+        })
+      )
+
+      const _expiredListing = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(publishedListing.ok)
+      const listings = await listingAdapter.getListingsWithApplicants({
+        type: 'published',
+      })
+      assert(listings.ok)
+
+      expect(listings.data).toEqual([
+        expect.objectContaining({ id: publishedListing.data.id }),
+      ])
+    })
+
+    it('only gets ready-for-offer listings', async () => {
+      const listingWithoutOffer = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(listingWithoutOffer.ok)
+      const listingWithOffer = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(listingWithOffer.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listingWithOffer.data.id })
+      )
+
+      const expiredListingOffer = await offerAdapter.create(db, {
+        applicantId: applicant.id,
+        expiresAt: new Date(),
+        listingId: listingWithOffer.data.id,
+        status: OfferStatus.Active,
+        selectedApplicants: [
+          factory.offerApplicant.build({
+            applicantId: applicant.id,
+            listingId: listingWithOffer.data.id,
+          }),
+        ],
+      })
+
+      assert(expiredListingOffer.ok)
+
+      const listings = await listingAdapter.getListingsWithApplicants({
+        type: 'ready-for-offer',
+      })
+      assert(listings.ok)
+
+      expect(listings.data).toEqual([
+        expect.objectContaining({ id: listingWithoutOffer.data.id }),
+      ])
+    })
+
+    it('only gets offered listings', async () => {
+      const listingWithoutOffer = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(listingWithoutOffer.ok)
+      const listingWithOffer = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(listingWithOffer.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listingWithOffer.data.id })
+      )
+
+      const expiredListingOffer = await offerAdapter.create(db, {
+        applicantId: applicant.id,
+        expiresAt: new Date(),
+        listingId: listingWithOffer.data.id,
+        status: OfferStatus.Active,
+        selectedApplicants: [
+          factory.offerApplicant.build({
+            applicantId: applicant.id,
+            listingId: listingWithOffer.data.id,
+          }),
+        ],
+      })
+
+      assert(expiredListingOffer.ok)
+
+      const listings = await listingAdapter.getListingsWithApplicants({
+        type: 'offered',
+      })
+      assert(listings.ok)
+
+      expect(listings.data).toEqual([
+        expect.objectContaining({ id: listingWithOffer.data.id }),
+      ])
+    })
+
+    it('only gets historical listings', async () => {
+      const activeListing = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Active,
+        })
+      )
+
+      assert(activeListing.ok)
+      const historicalListing = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Assigned,
+        })
+      )
+
+      assert(historicalListing.ok)
+
+      const listings = await listingAdapter.getListingsWithApplicants({
+        type: 'historical',
+      })
+      assert(listings.ok)
+
+      expect(listings.data).toEqual([
+        expect.objectContaining({ id: historicalListing.data.id }),
+      ])
+    })
+  })
+})

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -66,7 +66,7 @@ describe(listingAdapter.getListingsWithApplicants, () => {
 
       assert(publishedListing.ok)
       const listings = await listingAdapter.getListingsWithApplicants({
-        type: 'published',
+        by: { type: 'published' },
       })
       assert(listings.ok)
 
@@ -112,7 +112,7 @@ describe(listingAdapter.getListingsWithApplicants, () => {
       assert(expiredListingOffer.ok)
 
       const listings = await listingAdapter.getListingsWithApplicants({
-        type: 'ready-for-offer',
+        by: { type: 'ready-for-offer' },
       })
       assert(listings.ok)
 
@@ -158,7 +158,7 @@ describe(listingAdapter.getListingsWithApplicants, () => {
       assert(expiredListingOffer.ok)
 
       const listings = await listingAdapter.getListingsWithApplicants({
-        type: 'offered',
+        by: { type: 'offered' },
       })
       assert(listings.ok)
 
@@ -186,7 +186,7 @@ describe(listingAdapter.getListingsWithApplicants, () => {
       assert(historicalListing.ok)
 
       const listings = await listingAdapter.getListingsWithApplicants({
-        type: 'historical',
+        by: { type: 'historical' },
       })
       assert(listings.ok)
 

--- a/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
@@ -21,7 +21,7 @@ afterAll(async () => {
 })
 
 describe('listing-adapter', () => {
-  describe(listingAdapter.getAllListingsWithApplicants, () => {
+  describe(listingAdapter.getListingsWithApplicants, () => {
     it('returns a formatted list of listings and corresponding applicants', async () => {
       const listing1 = await listingAdapter.createListing(
         factory.listing.build({ rentalObjectCode: '1' })
@@ -37,7 +37,10 @@ describe('listing-adapter', () => {
       await listingAdapter.createApplication(
         factory.applicant.build({ listingId: listing2.data.id })
       )
-      const [fst, snd] = await listingAdapter.getAllListingsWithApplicants()
+      const listings = await listingAdapter.getListingsWithApplicants()
+      assert(listings.ok)
+      const [fst, snd] = listings.data
+
       expect(fst.applicants).toHaveLength(1)
       expect(fst.applicants?.[0]?.listingId).toBe(fst.id)
 

--- a/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
@@ -21,34 +21,6 @@ afterAll(async () => {
 })
 
 describe('listing-adapter', () => {
-  describe(listingAdapter.getListingsWithApplicants, () => {
-    it('returns a formatted list of listings and corresponding applicants', async () => {
-      const listing1 = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
-      )
-      const listing2 = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '2' })
-      )
-      assert(listing1.ok)
-      assert(listing2.ok)
-      await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listing1.data.id })
-      )
-      await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listing2.data.id })
-      )
-      const listings = await listingAdapter.getListingsWithApplicants()
-      assert(listings.ok)
-      const [fst, snd] = listings.data
-
-      expect(fst.applicants).toHaveLength(1)
-      expect(fst.applicants?.[0]?.listingId).toBe(fst.id)
-
-      expect(snd.applicants).toHaveLength(1)
-      expect(snd.applicants?.[0]?.listingId).toBe(snd.id)
-    })
-  })
-
   describe(listingAdapter.createListing, () => {
     it('inserts a new listing in the database', async () => {
       const insertedListing = await listingAdapter.createListing(

--- a/src/services/lease-service/tests/index.test.ts
+++ b/src/services/lease-service/tests/index.test.ts
@@ -7,10 +7,7 @@ import { Lease } from 'onecore-types'
 import { routes } from '../index'
 import * as tenantLeaseAdapter from '../adapters/xpand/tenant-lease-adapter'
 import * as xpandSoapAdapter from '../adapters/xpand/xpand-soap-adapter'
-import * as listingAdapter from '../adapters/listing-adapter'
 import { leaseTypes } from '../../../constants/leaseTypes'
-import * as factory from './factories'
-import * as getTenantService from '../get-tenant'
 
 const app = new Koa()
 const router = new KoaRouter()
@@ -259,57 +256,6 @@ describe('lease-service', () => {
       expect(getLeaseSpy).toHaveBeenCalled()
 
       expect(res.body.content.leaseId).toEqual('406-097-11-0201/06')
-    })
-  })
-
-  describe('GET /listing/:listingId/applicants/details', () => {
-    it('responds with 404 if no listing found', async () => {
-      const getListingSpy = jest
-        .spyOn(listingAdapter, 'getListingById')
-        .mockResolvedValueOnce(undefined)
-
-      const res = await request(app.callback()).get(
-        '/listing/1337/applicants/details'
-      )
-      expect(getListingSpy).toHaveBeenCalled()
-      expect(res.status).toBe(404)
-    })
-
-    it('responds with 200 on success', async () => {
-      const listingId = 1337
-      const applicant1 = factory.applicant.build({
-        listingId: listingId,
-        nationalRegistrationNumber: '194808075577',
-      })
-
-      const applicant2 = factory.applicant.build({
-        listingId: listingId,
-        nationalRegistrationNumber: '198001011234',
-      })
-
-      const listing = factory.listing.build({
-        id: listingId,
-        publishedFrom: new Date(),
-        publishedTo: new Date(),
-        vacantFrom: new Date(),
-        applicants: [applicant1, applicant2],
-      })
-
-      const getListingSpy = jest
-        .spyOn(listingAdapter, 'getListingById')
-        .mockResolvedValueOnce(listing)
-
-      const getTenantSpy = jest
-        .spyOn(getTenantService, 'getTenant')
-        .mockResolvedValue({ ok: true, data: factory.tenant.build() })
-
-      const res = await request(app.callback()).get(
-        '/listing/1337/applicants/details'
-      )
-      expect(getListingSpy).toHaveBeenCalled()
-      expect(getTenantSpy).toHaveBeenCalled()
-      expect(res.status).toBe(200)
-      expect(res.body).toBeDefined()
     })
   })
 

--- a/src/services/lease-service/tests/routes/listings.test.ts
+++ b/src/services/lease-service/tests/routes/listings.test.ts
@@ -1,0 +1,124 @@
+import request from 'supertest'
+import Koa from 'koa'
+import KoaRouter from '@koa/router'
+import bodyParser from 'koa-bodyparser'
+
+import * as listingAdapter from '../../adapters/listing-adapter'
+import * as factory from './../factories'
+import * as getTenantService from '../../get-tenant'
+
+import { routes } from '../../routes/listings'
+
+const app = new Koa()
+const router = new KoaRouter()
+routes(router)
+app.use(bodyParser())
+app.use(router.routes())
+
+beforeEach(jest.resetAllMocks)
+describe('GET /listing/:listingId/applicants/details', () => {
+  it('responds with 404 if no listing found', async () => {
+    const getListingSpy = jest
+      .spyOn(listingAdapter, 'getListingById')
+      .mockResolvedValueOnce(undefined)
+
+    const res = await request(app.callback()).get(
+      '/listing/1337/applicants/details'
+    )
+    expect(getListingSpy).toHaveBeenCalled()
+    expect(res.status).toBe(404)
+  })
+
+  it('responds with 200 on success', async () => {
+    const listingId = 1337
+    const applicant1 = factory.applicant.build({
+      listingId: listingId,
+      nationalRegistrationNumber: '194808075577',
+    })
+
+    const applicant2 = factory.applicant.build({
+      listingId: listingId,
+      nationalRegistrationNumber: '198001011234',
+    })
+
+    const listing = factory.listing.build({
+      id: listingId,
+      publishedFrom: new Date(),
+      publishedTo: new Date(),
+      vacantFrom: new Date(),
+      applicants: [applicant1, applicant2],
+    })
+
+    const getListingSpy = jest
+      .spyOn(listingAdapter, 'getListingById')
+      .mockResolvedValueOnce(listing)
+
+    const getTenantSpy = jest
+      .spyOn(getTenantService, 'getTenant')
+      .mockResolvedValue({ ok: true, data: factory.tenant.build() })
+
+    const res = await request(app.callback()).get(
+      '/listing/1337/applicants/details'
+    )
+    expect(getListingSpy).toHaveBeenCalled()
+    expect(getTenantSpy).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(res.body).toBeDefined()
+  })
+})
+
+describe('GET /listings-with-applicants', () => {
+  const getListingsWithApplicantsSpy = jest.spyOn(
+    listingAdapter,
+    'getListingsWithApplicants'
+  )
+
+  it('responds with 200 and listings', async () => {
+    getListingsWithApplicantsSpy.mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(1),
+    })
+
+    const res = await request(app.callback()).get('/listings-with-applicants')
+    expect(getListingsWithApplicantsSpy).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: [expect.objectContaining({ id: expect.any(Number) })],
+    })
+  })
+
+  it('gets applicants with filter if valid query param', async () => {
+    getListingsWithApplicantsSpy.mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(1),
+    })
+
+    const res = await request(app.callback()).get(
+      '/listings-with-applicants?type=published'
+    )
+    expect(getListingsWithApplicantsSpy).toHaveBeenCalledWith({
+      by: { type: 'published' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: [expect.objectContaining({ id: expect.any(Number) })],
+    })
+  })
+
+  it('gets applicants without filter if invalid query param', async () => {
+    getListingsWithApplicantsSpy.mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(1),
+    })
+
+    const res = await request(app.callback()).get(
+      '/listings-with-applicants?type=invalid-value'
+    )
+
+    expect(getListingsWithApplicantsSpy).toHaveBeenCalledWith(undefined)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: [expect.objectContaining({ id: expect.any(Number) })],
+    })
+  })
+})


### PR DESCRIPTION
- Rename `getAllListingsWithApplicants` to `getListingsWithApplicants`
- Add optional filter object param to `getListingWithApplicants` that lets consumer filter listings by four categories:
  - 'published' - Where listing status is "Active"
  - 'ready-for-offer' - Where listing status is "Expired" and there is no existing offer for the same listing
  - 'offered' - Where listing status is "Expired" and there is an existing offer for the same listing
  - 'historical' - Where listing status is "Assigned"

- Handle query param in route

https://linear.app/mimer-onecore/issue/MIM-157/medarbetarportalen-listning-av-bilplatser-med-flikar