### PR TITLE
MIM-186: Ensure ready-for-offer listings has applicants

### DIFF
--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -264,11 +264,17 @@ const getListingsWithApplicants = async (
       .with({ type: 'ready-for-offer' }, () =>
         db.raw(
           `WHERE l.Status = ? 
+          AND EXISTS (
+            SELECT 1
+            FROM applicant a
+            WHERE a.ListingId = l.Id
+          )
           AND NOT EXISTS (
             SELECT 1
             FROM offer o
             WHERE o.ListingId = l.Id
-          )`,
+          )
+          `,
           [ListingStatus.Expired]
         )
       )

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -93,7 +93,7 @@ describe(listingAdapter.getListingsWithApplicants, () => {
 
       assert(listingWithOffer.ok)
       const applicant = await listingAdapter.createApplication(
-        factory.applicant.build({ listingId: listingWithOffer.data.id })
+        factory.applicant.build({ listingId: listingWithoutOffer.data.id })
       )
 
       const expiredListingOffer = await offerAdapter.create(db, {
@@ -118,6 +118,40 @@ describe(listingAdapter.getListingsWithApplicants, () => {
 
       expect(listings.data).toEqual([
         expect.objectContaining({ id: listingWithoutOffer.data.id }),
+      ])
+    })
+
+    it('ready-for-offer listings has applicants', async () => {
+      const listingWithApplicants = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(listingWithApplicants.ok)
+      const listingWithoutApplicants = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Expired,
+        })
+      )
+
+      assert(listingWithoutApplicants.ok)
+      const applicant = await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: listingWithApplicants.data.id })
+      )
+
+      assert(applicant)
+
+      const listings = await listingAdapter.getListingsWithApplicants({
+        by: { type: 'ready-for-offer' },
+      })
+
+      assert(listings.ok)
+
+      expect(listings.data).toEqual([
+        expect.objectContaining({ id: listingWithApplicants.data.id }),
       ])
     })
 


### PR DESCRIPTION
Ready for offer listings should mean they have applicants