### PR TITLE
Fix: mim-181-retrieve-tenant-without-waiting-list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7549,9 +7549,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.31.0.tgz",
-      "integrity": "sha512-9MFoOW78gfylIfEOHJqw/RkbL8Q6526dnLBoZcgav8yC69X9Ef6ufvIZMxO4k69HmbmbiNb7QbA0o5JPnG43jQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-1.33.0.tgz",
+      "integrity": "sha512-cE9HYEPG1SqyebH0wacugVASeiny5okzgwWglsfYvrAEoaLTPx52+WisUWjG5Nfz1XS0sv/D2oec+NtxwVM8Kg==",
       "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"

--- a/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -3,9 +3,9 @@ import { XMLParser } from 'fast-xml-parser'
 import createHttpError from 'http-errors'
 
 import Config from '../../../../common/config'
-import { WaitingList } from 'onecore-types'
 import { logger } from 'onecore-utilities'
 import { AdapterResult } from '../types'
+import { WaitingListType } from 'onecore-types'
 
 const createLease = async (
   fromDate: Date,
@@ -85,71 +85,35 @@ const createLease = async (
   }
 }
 
-const getWaitingList = async (
-  nationalRegistrationNumber: string
-): Promise<AdapterResult<Array<WaitingList>, 'not-found'>> => {
-  const headers = getHeaders()
-
-  const xml = `
-   <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:ser="http://incit.xpand.eu/service/" xmlns:inc="http://incit.xpand.eu/">
-   <soap:Header xmlns:wsa='http://www.w3.org/2005/08/addressing'><wsa:Action>http://incit.xpand.eu/service/GetWaitingListTimes/GetWaitingListTimes</wsa:Action><wsa:To>${Config.xpandSoap.url}</wsa:To></soap:Header>
-   <soap:Body>
-      <ser:GetDataByContactRequest>
-         <inc:CivicNumber>${nationalRegistrationNumber}</inc:CivicNumber><!--add as param:-->
-         <inc:CompanyCode>001</inc:CompanyCode>
-         <inc:MessageCulture>${Config.xpandSoap.messageCulture}</inc:MessageCulture>
-      </ser:GetDataByContactRequest>
-   </soap:Body>
-</soap:Envelope>`
-
-  const { response } = await soapRequest({
-    url: Config.xpandSoap.url,
-    headers: headers,
-    xml: xml,
-  })
-  const { body } = response
-
-  const options = {
-    ignoreAttributes: false,
-    ignoreNameSpace: false,
-    removeNSPrefix: true,
+const addApplicantToToWaitingList = async (
+  nationalRegistrationNumber: string,
+  contactCode: string,
+  waitingListType: WaitingListType.ParkingSpace
+) => {
+  console.log('waiting list type', waitingListType)
+  if (waitingListType == WaitingListType.ParkingSpace) {
+    await addToWaitingList(
+      nationalRegistrationNumber,
+      contactCode,
+      'Bilplats (intern)'
+    )
+    await addToWaitingList(
+      nationalRegistrationNumber,
+      contactCode,
+      'Bilplats (extern)'
+    )
+    return
   }
-
-  const parser = new XMLParser(options)
-
-  const parsedResponse =
-    parser.parse(body)['Envelope']['Body']['GetWaitingListTimeResult']
-
-  if (!parsedResponse['WaitingListTimes']) {
-    return { ok: false, err: 'not-found' }
-  } else {
-    try {
-      const waitingList: WaitingList[] = []
-
-      for (const item of parsedResponse['WaitingListTimes'][
-        'WaitingListTimeDataContract'
-      ]) {
-        const newItem: WaitingList = {
-          applicantCaption: item.ApplicantCaption,
-          contactCode: item.ApplicantCode,
-          contractFromApartment: new Date(item.ContractFromApartment),
-          queuePoints: item.QueuePoints,
-          queuePointsSocialConnection: item.QueuePointsSocialConnection,
-          waitingListFrom: new Date(item.WaitingListFrom),
-          waitingListTypeCaption: item.WaitingListTypeCaption,
-        }
-
-        waitingList.push(newItem)
-      }
-      return { ok: true, data: waitingList }
-    } catch (e) {
-      logger.error(e, 'Error getting waiting list using Xpand SOAP API')
-      throw createHttpError(500, 'Unknown error when parsing body')
-    }
-  }
+  logger.error(
+    `Add to Waiting list type ${waitingListType} not implemented yet`
+  )
+  throw createHttpError(
+    500,
+    `Add to Waiting list type ${waitingListType} not implemented yet`
+  )
 }
 
-const addApplicantToToWaitingList = async (
+const addToWaitingList = async (
   nationalRegistrationNumber: string,
   contactCode: string,
   waitingListTypeCaption: string
@@ -207,6 +171,32 @@ const addApplicantToToWaitingList = async (
 }
 
 const removeApplicantFromWaitingList = async (
+  nationalRegistrationNumber: string,
+  contactCode: string,
+  waitingListType: WaitingListType
+): Promise<AdapterResult<undefined, 'not-in-waiting-list' | 'unknown'>> => {
+  console.log('waiting list type', waitingListType)
+  if (waitingListType == WaitingListType.ParkingSpace) {
+    await removeFromWaitingList(
+      nationalRegistrationNumber,
+      contactCode,
+      'Bilplats (intern)'
+    )
+    return await removeFromWaitingList(
+      nationalRegistrationNumber,
+      contactCode,
+      'Bilplats (extern)'
+    )
+  }
+  logger.error(
+    `Remove from Waiting list type ${waitingListType} not implemented yet`
+  )
+  throw createHttpError(
+    500,
+    `Remove from Waiting list type ${waitingListType} not implemented yet`
+  )
+}
+const removeFromWaitingList = async (
   nationalRegistrationNumber: string,
   contactCode: string,
   waitingListTypeCaption: string
@@ -345,7 +335,6 @@ function getHeaders() {
 
 export {
   createLease,
-  getWaitingList,
   addApplicantToToWaitingList,
   removeApplicantFromWaitingList,
   healthCheck,

--- a/src/services/lease-service/get-tenant.ts
+++ b/src/services/lease-service/get-tenant.ts
@@ -39,19 +39,6 @@ export async function getTenant(params: {
     return { ok: false, err: 'contact-not-tenant' }
   }
 
-  const waitingList = await xpandSoapAdapter.getWaitingList(
-    contact.data.nationalRegistrationNumber
-  )
-
-  if (!waitingList.ok) {
-    return { ok: false, err: 'get-waiting-lists' }
-  }
-
-  const waitingListForInternalParkingSpace =
-    priorityListService.parseWaitingListForInternalParkingSpace(
-      waitingList.data
-    )
-
   const leases = await tenantLeaseAdapter.getLeasesForContactCode(
     contact.data.contactCode,
     'true',
@@ -138,9 +125,6 @@ export async function getTenant(params: {
     ok: true,
     data: {
       ...contact.data,
-      queuePoints: waitingListForInternalParkingSpace
-        ? waitingListForInternalParkingSpace.queuePoints
-        : 0,
       address: contact.data.address,
       currentHousingContract,
       upcomingHousingContract,

--- a/src/services/lease-service/get-tenant.ts
+++ b/src/services/lease-service/get-tenant.ts
@@ -52,13 +52,6 @@ export async function getTenant(params: {
       waitingList.data
     )
 
-  if (!waitingListForInternalParkingSpace) {
-    return {
-      ok: false,
-      err: 'waiting-list-internal-parking-space-not-found',
-    }
-  }
-
   const leases = await tenantLeaseAdapter.getLeasesForContactCode(
     contact.data.contactCode,
     'true',
@@ -145,7 +138,9 @@ export async function getTenant(params: {
     ok: true,
     data: {
       ...contact.data,
-      queuePoints: waitingListForInternalParkingSpace.queuePoints,
+      queuePoints: waitingListForInternalParkingSpace
+        ? waitingListForInternalParkingSpace.queuePoints
+        : 0,
       address: contact.data.address,
       currentHousingContract,
       upcomingHousingContract,

--- a/src/services/lease-service/priority-list-service.ts
+++ b/src/services/lease-service/priority-list-service.ts
@@ -5,14 +5,7 @@
  */
 
 import { logger } from 'onecore-utilities'
-import {
-  DetailedApplicant,
-  Lease,
-  Listing,
-  ParkingSpaceApplicationCategory,
-  parkingSpaceApplicationCategoryTranslation,
-  WaitingList,
-} from 'onecore-types'
+import { DetailedApplicant, Lease, Listing } from 'onecore-types'
 
 import { leaseTypes } from '../../constants/leaseTypes'
 
@@ -190,21 +183,6 @@ const isLeaseActiveOrUpcoming = (lease: Lease): boolean => {
   )
 }
 
-const parseWaitingListForInternalParkingSpace = (
-  waitingLists: WaitingList[]
-): WaitingList | undefined => {
-  for (const waitingList of waitingLists) {
-    if (
-      parkingSpaceApplicationCategoryTranslation[
-        waitingList.waitingListTypeCaption
-      ] == ParkingSpaceApplicationCategory.internal
-    ) {
-      return waitingList
-    }
-  }
-  return undefined
-}
-
 //this function is based on xpand rules that there can be max 1 current active contract and 1 upcoming contract
 const parseLeasesForHousingContracts = (
   leases: Lease[]
@@ -280,7 +258,6 @@ export {
   addPriorityToApplicantsBasedOnRentalRules,
   sortApplicantsBasedOnRentalRules,
   assignPriorityToApplicantBasedOnRentalRules,
-  parseWaitingListForInternalParkingSpace,
   parseLeasesForHousingContracts,
   parseLeasesForParkingSpaces,
   isLeaseActiveOrUpcoming,

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -574,7 +574,9 @@ export const routes = (router: KoaRouter) => {
             ...applicant,
             contactCode: tenant.data.contactCode,
             nationalRegistrationNumber: tenant.data.nationalRegistrationNumber,
-            queuePoints: tenant.data.queuePoints,
+            queuePoints: tenant.data.parkingSpaceWaitingList
+              ? tenant.data.parkingSpaceWaitingList.queuePoints
+              : 0,
             address: tenant.data.address,
             currentHousingContract: tenant.data.currentHousingContract,
             upcomingHousingContract: tenant.data.upcomingHousingContract,

--- a/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
@@ -1,3 +1,4 @@
+import { WaitingListType } from 'onecore-types'
 import * as tenantLeaseAdapter from '../../../adapters/xpand/tenant-lease-adapter'
 
 jest.mock('knex', () => () => ({
@@ -25,6 +26,8 @@ jest.mock('knex', () => () => ({
           emailAddress: 'noreply@mimer.nu  ',
           keycmobj: '12345',
           contactKey: '_ADBAEC',
+          queueName: 'Bilplats (intern)',
+          queueTime: new Date('2024-10-17T00:00:00.000Z'),
         },
       ])
     )
@@ -75,6 +78,11 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
         ],
         emailAddress: 'redacted',
         isTenant: false,
+        parkingSpaceWaitingList: {
+          queuePoints: 13,
+          queueTime: new Date('2024-10-17T00:00:00.000Z'),
+          type: WaitingListType.ParkingSpace,
+        },
       },
     })
   })

--- a/src/services/lease-service/tests/priority-list-service.test.ts
+++ b/src/services/lease-service/tests/priority-list-service.test.ts
@@ -1,48 +1,14 @@
-import { Lease, LeaseStatus, WaitingList } from 'onecore-types'
+import { Lease, LeaseStatus } from 'onecore-types'
 import {
   addPriorityToApplicantsBasedOnRentalRules,
   assignPriorityToApplicantBasedOnRentalRules,
   isLeaseActiveOrUpcoming,
   parseLeasesForHousingContracts,
   parseLeasesForParkingSpaces,
-  parseWaitingListForInternalParkingSpace,
   sortApplicantsBasedOnRentalRules,
 } from '../priority-list-service'
 import * as factory from './factories'
 import { leaseTypes } from '../../../constants/leaseTypes'
-
-const mockedWaitingListWithInteralParkingSpace: WaitingList[] = [
-  {
-    applicantCaption: 'Foo Bar',
-    contactCode: 'P12345',
-    contractFromApartment: new Date('2024-02-29T23:00:00.000Z'),
-    queuePoints: 45,
-    queuePointsSocialConnection: 0,
-    waitingListFrom: new Date('2024-01-31T23:00:00.000Z'),
-    waitingListTypeCaption: 'Bostad',
-  },
-  {
-    applicantCaption: 'Foo Bar',
-    contactCode: 'P12345',
-    contractFromApartment: new Date('2024-02-29T23:00:00.000Z'),
-    queuePoints: 45,
-    queuePointsSocialConnection: 0,
-    waitingListFrom: new Date('2024-01-31T23:00:00.000Z'),
-    waitingListTypeCaption: 'Bilplats (intern)',
-  },
-]
-
-const mockedWaitingListWithoutInternalParkingSpace: WaitingList[] = [
-  {
-    applicantCaption: 'Foo Bar',
-    contactCode: 'P12345',
-    contractFromApartment: new Date('2024-02-29T23:00:00.000Z'),
-    queuePoints: 45,
-    queuePointsSocialConnection: 0,
-    waitingListFrom: new Date('2024-01-31T23:00:00.000Z'),
-    waitingListTypeCaption: 'Bostad',
-  },
-]
 
 //dynamic dates for active and upcoming contracts
 const currentDate = new Date()
@@ -50,24 +16,6 @@ const thirtyDaysInThePastDate = new Date()
 const thirtyDaysInTheFutureDate = new Date()
 thirtyDaysInThePastDate.setDate(currentDate.getDate() + 30)
 thirtyDaysInTheFutureDate.setDate(currentDate.getDate() + 30)
-
-describe('parseWaitingList', () => {
-  it('should return waitingList for internal parking space', async () => {
-    const result = parseWaitingListForInternalParkingSpace(
-      mockedWaitingListWithInteralParkingSpace
-    )
-
-    expect(result).toBeDefined()
-    expect(result).toEqual(mockedWaitingListWithInteralParkingSpace[1])
-  })
-
-  it('should return undefined for waitingList without internal parking space', async () => {
-    const result = parseWaitingListForInternalParkingSpace(
-      mockedWaitingListWithoutInternalParkingSpace
-    )
-    expect(result).toBeUndefined()
-  })
-})
 
 describe('parseLeasesForHousingContract', () => {
   it('should return 1 housing contract if only 1 active housing contract', async () => {

--- a/src/services/lease-service/tests/routes/contacts.test.ts
+++ b/src/services/lease-service/tests/routes/contacts.test.ts
@@ -6,6 +6,7 @@ import bodyParser from 'koa-bodyparser'
 import { routes } from '../../routes/contacts'
 import * as tenantLeaseAdapter from '../../adapters/xpand/tenant-lease-adapter'
 import * as xPandSoapAdapter from '../../adapters/xpand/xpand-soap-adapter'
+import { WaitingListType } from 'onecore-types'
 
 const app = new Koa()
 const router = new KoaRouter()
@@ -48,7 +49,7 @@ describe('GET /contacts/search', () => {
     })
   })
 
-  describe('POST /contact/waitingList/:nationalRegistrationNumber/reset', () => {
+  describe('POST /contacts/:nationalRegistrationNumber/waitingLists/reset', () => {
     it('responds with 200 and a message upon success', async () => {
       jest
         .spyOn(xPandSoapAdapter, 'removeApplicantFromWaitingList')
@@ -58,10 +59,10 @@ describe('GET /contacts/search', () => {
         .mockResolvedValue()
 
       const res = await request(app.callback())
-        .post('/contact/waitingList/1234567890/reset')
+        .post('/contacts/1234567890/waitingLists/reset')
         .send({
           contactCode: '123',
-          waitingListTypeCaption: 'Bilplatser (intern)',
+          waitingListType: WaitingListType.ParkingSpace,
         })
 
       expect(res.status).toBe(200)
@@ -81,10 +82,10 @@ describe('GET /contacts/search', () => {
         .mockResolvedValue()
 
       const res = await request(app.callback())
-        .post('/contact/waitingList/1234567890/reset')
+        .post('/contacts/1234567890/waitingLists/reset')
         .send({
           contactCode: '123',
-          waitingListTypeCaption: 'Bilplatser (intern)',
+          waitingListType: WaitingListType.ParkingSpace,
         })
 
       expect(res.status).toBe(404)
@@ -102,10 +103,10 @@ describe('GET /contacts/search', () => {
         .mockResolvedValue()
 
       const res = await request(app.callback())
-        .post('/contact/waitingList/1234567890/reset')
+        .post('/contacts/1234567890/waitingLists/reset')
         .send({
           contactCode: '123',
-          waitingListTypeCaption: 'Bilplatser (intern)',
+          waitingListType: WaitingListType.ParkingSpace,
         })
 
       expect(res.status).toBe(500)
@@ -125,10 +126,10 @@ describe('GET /contacts/search', () => {
         })
 
       const res = await request(app.callback())
-        .post('/contact/waitingList/1234567890/reset')
+        .post('/contacts/1234567890/waitingLists/reset')
         .send({
           contactCode: '123',
-          waitingListTypeCaption: 'Bilplatser (intern)',
+          waitingListType: WaitingListType.ParkingSpace,
         })
 
       expect(res.status).toBe(500)

--- a/src/services/lease-service/tests/waiting-list.test.ts
+++ b/src/services/lease-service/tests/waiting-list.test.ts
@@ -5,7 +5,6 @@ import bodyParser from 'koa-bodyparser'
 
 import { routes } from '../index'
 import * as xpandSoapAdapter from '../adapters/xpand/xpand-soap-adapter'
-import { WaitingList } from 'onecore-types'
 import { HttpStatusCode } from 'axios'
 
 const app = new Koa()
@@ -14,61 +13,14 @@ routes(router)
 app.use(bodyParser())
 app.use(router.routes())
 
-const mockedWaitingList: WaitingList[] = [
-  {
-    applicantCaption: 'Foo Bar',
-    contactCode: 'P12345',
-    contractFromApartment: new Date('2024-02-29T23:00:00.000Z'),
-    queuePoints: 45,
-    queuePointsSocialConnection: 0,
-    waitingListFrom: new Date('2024-01-31T23:00:00.000Z'),
-    waitingListTypeCaption: 'Bostad',
-  },
-  {
-    applicantCaption: 'Foo Bar',
-    contactCode: 'P12345',
-    contractFromApartment: new Date('2024-02-29T23:00:00.000Z'),
-    queuePoints: 45,
-    queuePointsSocialConnection: 0,
-    waitingListFrom: new Date('2024-01-31T23:00:00.000Z'),
-    waitingListTypeCaption: 'Bilplats (intern)',
-  },
-]
-describe('GET contact/waitingList', () => {
-  it('should return success', async () => {
-    const xpandAdapterSpy = jest
-      .spyOn(xpandSoapAdapter, 'getWaitingList')
-      .mockResolvedValue({ ok: true, data: mockedWaitingList })
-
-    const result = await request(app.callback()).get('/contact/waitingList/123')
-
-    expect(xpandAdapterSpy).toHaveBeenCalled()
-    expect(result.status).toEqual(200)
-  })
-
-  it('handles errors', async () => {
-    const xpandAdapterSpy = jest
-      .spyOn(xpandSoapAdapter, 'getWaitingList')
-      .mockImplementation(() => {
-        throw new Error('Oh no')
-      })
-
-    const result = await request(app.callback()).get('/contact/waitingList/123')
-
-    expect(xpandAdapterSpy).toHaveBeenCalled()
-    expect(result.status).toEqual(HttpStatusCode.InternalServerError)
-    expect(result.body).toEqual({ error: 'Oh no' })
-  })
-})
-
-describe('POST contact/waitingList', () => {
+describe('POST contacts/1234567890/waitingList', () => {
   it('should return success', async () => {
     const xpandAdapterSpy = jest
       .spyOn(xpandSoapAdapter, 'addApplicantToToWaitingList')
       .mockResolvedValue()
 
     const result = await request(app.callback()).post(
-      '/contact/waitingList/123'
+      '/contacts/1234567890/waitingLists'
     )
 
     expect(xpandAdapterSpy).toHaveBeenCalled()
@@ -83,7 +35,7 @@ describe('POST contact/waitingList', () => {
       })
 
     const result = await request(app.callback()).post(
-      '/contact/waitingList/123'
+      '/contacts/1234567890/waitingLists'
     )
 
     expect(xpandAdapterSpy).toHaveBeenCalled()


### PR DESCRIPTION
Waiting list rewrite:

Waiting has been moved from tenant to contact
Waiting lists is now retrieved from the xpand db together with other contact details