### PR TITLE
UTH-36: Handle duplicate listings

### DIFF
--- a/migrations/20241029104159_unique-listing-non-closed.js
+++ b/migrations/20241029104159_unique-listing-non-closed.js
@@ -1,0 +1,30 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex
+    .raw(`DROP INDEX unique_rental_object_code_status ON listing;`)
+    .then(() =>
+      knex.raw(`
+        CREATE UNIQUE INDEX unique_rental_object_code_status 
+        ON listing (RentalObjectCode)WHERE Status <> 3; -- i.e NOT ListingStatus.Closed
+      `)
+    )
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex
+    .raw(`DROP INDEX unique_rental_object_code_status ON listing;`)
+    .then(() =>
+      knex.raw(`
+        CREATE UNIQUE INDEX unique_rental_object_code_status 
+        ON listing (RentalObjectCode)
+        WHERE Status = 1; -- ListingStatus.Active
+      `)
+    )
+}

--- a/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
@@ -53,11 +53,11 @@ describe('listing-adapter', () => {
       })
     })
 
-    it('allows duplicate combination of other Listing statuses and RentalObjectCode', async () => {
+    it('allows duplicate combination of closed Listing statuses and RentalObjectCode', async () => {
       await listingAdapter.createListing(
         factory.listing.build({
           rentalObjectCode: '1',
-          status: ListingStatus.Active,
+          status: ListingStatus.Closed,
         })
       )
 


### PR DESCRIPTION
We should allow duplicate listings with the same RentalObjectCode when:
- existing listings have status Closed

Fixes https://linear.app/mimer-onecore/issue/UTH-36/tillat-dubletter-av-listing-vid-soap-synk