### PR TITLE
Feat:UTH-117 Get Active Listings by Rental Object Code

### DIFF
--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -103,17 +103,18 @@ const createListing = async (
 }
 
 /**
- * Checks if a listing already exists based on unique criteria.
+ * Checks if an active listing already exists based on unique criteria.
  *
- * @param {string} rentalObjectCode - The rental object code of the listing (originally from xpand)
+ * @param {string} rentalObjectCode - The rental object code of the active listing (originally from xpand)
  * @returns {Promise<Listing>} - Promise that resolves to the existing listing if it exists.
  */
-const getListingByRentalObjectCode = async (
+const getActiveListingByRentalObjectCode = async (
   rentalObjectCode: string
 ): Promise<Listing | undefined> => {
   const listing = await db<DbListing>('Listing')
     .where({
       RentalObjectCode: rentalObjectCode,
+      Status: ListingStatus.Active,
     })
     .first()
 
@@ -475,7 +476,7 @@ export {
   createListing,
   createApplication,
   getListingById,
-  getListingByRentalObjectCode,
+  getActiveListingByRentalObjectCode,
   getExpiredListingsWithNoOffers,
   getListingsWithApplicants,
   getApplicantById,

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -290,10 +290,10 @@ export const routes = (router: KoaRouter) => {
 
   /**
    * @swagger
-   * /listings/by-code/{rentalObjectCode}:
+   * /listings/active/by-code/{rentalObjectCode}:
    *   get:
-   *     summary: Get a listing by Rental Object Code
-   *     description: Fetches a listing from the database using its Rental Object Code.
+   *     summary: Get an active listing by Rental Object Code
+   *     description: Fetches an active listing from the database using its Rental Object Code.
    *     tags:
    *       - Listings
    *     parameters:
@@ -330,12 +330,14 @@ export const routes = (router: KoaRouter) => {
    *                   type: string
    *                   description: The error message.
    */
-  router.get('/listings/by-code/:rentalObjectCode', async (ctx) => {
+  router.get('/listings/active/by-code/:rentalObjectCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     try {
       const rentaLObjectCode = ctx.params.rentalObjectCode
       const listing =
-        await listingAdapter.getListingByRentalObjectCode(rentaLObjectCode)
+        await listingAdapter.getActiveListingByRentalObjectCode(
+          rentaLObjectCode
+        )
       if (listing == undefined) {
         ctx.status = 404
         ctx.body = { reason: 'Listing not found', ...metadata }

--- a/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
@@ -74,20 +74,32 @@ describe('listing-adapter', () => {
     })
   })
 
-  describe(listingAdapter.getListingByRentalObjectCode, () => {
-    it('returns a listing by rental object code', async () => {
+  describe(listingAdapter.getActiveListingByRentalObjectCode, () => {
+    it('returns an active listing by rental object code', async () => {
       const insertedListing = await listingAdapter.createListing(
-        factory.listing.build({ rentalObjectCode: '1' })
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Active,
+        })
       )
       assert(insertedListing.ok)
+      const insertedListing2 = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Closed,
+        })
+      )
+      assert(insertedListing2.ok)
+
       const listingFromDatabase =
-        await listingAdapter.getListingByRentalObjectCode(
+        await listingAdapter.getActiveListingByRentalObjectCode(
           insertedListing.data.rentalObjectCode
         )
       expect(listingFromDatabase?.rentalObjectCode).toBeDefined()
       expect(listingFromDatabase?.rentalObjectCode).toEqual(
         insertedListing.data.rentalObjectCode
       )
+      expect(listingFromDatabase?.status).toEqual(ListingStatus.Active)
     })
   })
 

--- a/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
@@ -1,6 +1,8 @@
 import { WaitingListType } from 'onecore-types'
 import * as tenantLeaseAdapter from '../../../adapters/xpand/tenant-lease-adapter'
 
+const queueTime = new Date('2024-10-17T00:00:00.000Z')
+
 jest.mock('knex', () => () => ({
   raw: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
@@ -27,7 +29,7 @@ jest.mock('knex', () => () => ({
           keycmobj: '12345',
           contactKey: '_ADBAEC',
           queueName: 'Bilplats (intern)',
-          queueTime: new Date('2024-10-17T00:00:00.000Z'),
+          queueTime: queueTime,
         },
       ])
     )
@@ -50,6 +52,10 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
     const contact = await tenantLeaseAdapter.getContactByContactCode(
       'P123456',
       undefined
+    )
+
+    const queuePonts = Math.round(
+      (new Date().getTime() - queueTime.getTime()) / (1000 * 3600 * 24)
     )
 
     expect(contact).toStrictEqual({
@@ -79,7 +85,7 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
         emailAddress: 'redacted',
         isTenant: false,
         parkingSpaceWaitingList: {
-          queuePoints: 13,
+          queuePoints: queuePonts,
           queueTime: new Date('2024-10-17T00:00:00.000Z'),
           type: WaitingListType.ParkingSpace,
         },


### PR DESCRIPTION
* The route /listings/by-code has been remade to only return active listings under the new route name /listings/active/by-code