### PR TITLE
UTH-125: No parking spaces when getting 'historical'

### DIFF
--- a/migrations/20241112125047_unique-listing-non-closed-assigned.js
+++ b/migrations/20241112125047_unique-listing-non-closed-assigned.js
@@ -1,0 +1,30 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex
+    .raw(`DROP INDEX unique_rental_object_code_status ON listing;`)
+    .then(() =>
+      knex.raw(`
+        CREATE UNIQUE INDEX unique_rental_object_code_status 
+        ON listing (RentalObjectCode)
+        WHERE Status <> 2 AND Status <> 3
+      `)
+    )
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex
+    .raw(`DROP INDEX unique_rental_object_code_status ON listing;`)
+    .then(() =>
+      knex.raw(`
+        CREATE UNIQUE INDEX unique_rental_object_code_status 
+        ON listing (RentalObjectCode) WHERE Status <> 3; -- i.e NOT ListingStatus.Closed
+      `)
+    )
+}

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -261,7 +261,10 @@ const getListingsWithApplicants = async (
         db.raw('WHERE l.Status = ?', [ListingStatus.Active])
       )
       .with({ type: 'historical' }, () =>
-        db.raw('WHERE l.Status = ?', [ListingStatus.Assigned])
+        db.raw('WHERE l.Status = ? OR l.Status = ?', [
+          ListingStatus.Assigned,
+          ListingStatus.Closed,
+        ])
       )
       .with({ type: 'ready-for-offer' }, () =>
         db.raw(

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -261,10 +261,16 @@ const getListingsWithApplicants = async (
         db.raw('WHERE l.Status = ?', [ListingStatus.Active])
       )
       .with({ type: 'historical' }, () =>
-        db.raw('WHERE l.Status = ? OR l.Status = ?', [
-          ListingStatus.Assigned,
-          ListingStatus.Closed,
-        ])
+        db.raw(
+          `WHERE l.Status = ?
+           OR (l.Status = ? AND EXISTS (
+              SELECT 1
+              FROM applicant a
+              WHERE a.ListingId = l.Id
+           ))
+          `,
+          [ListingStatus.Assigned, ListingStatus.Closed]
+        )
       )
       .with({ type: 'ready-for-offer' }, () =>
         db.raw(

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -268,14 +268,22 @@ describe(listingAdapter.getListingsWithApplicants, () => {
       )
 
       assert(activeListing.ok)
-      const historicalListing = await listingAdapter.createListing(
+      const assignedListing = await listingAdapter.createListing(
         factory.listing.build({
           rentalObjectCode: '2',
           status: ListingStatus.Assigned,
         })
       )
 
-      assert(historicalListing.ok)
+      const closedListing = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Closed,
+        })
+      )
+
+      assert(assignedListing.ok)
+      assert(closedListing.ok)
 
       const listings = await listingAdapter.getListingsWithApplicants({
         by: { type: 'historical' },
@@ -283,7 +291,8 @@ describe(listingAdapter.getListingsWithApplicants, () => {
       assert(listings.ok)
 
       expect(listings.data).toEqual([
-        expect.objectContaining({ id: historicalListing.data.id }),
+        expect.objectContaining({ id: assignedListing.data.id }),
+        expect.objectContaining({ id: closedListing.data.id }),
       ])
     })
 

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -275,6 +275,11 @@ describe(listingAdapter.getListingsWithApplicants, () => {
         })
       )
 
+      assert(assignedListing.ok)
+      await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: assignedListing.data.id })
+      )
+
       const closedListing = await listingAdapter.createListing(
         factory.listing.build({
           rentalObjectCode: '2',
@@ -282,14 +287,15 @@ describe(listingAdapter.getListingsWithApplicants, () => {
         })
       )
 
-      assert(assignedListing.ok)
       assert(closedListing.ok)
+      await listingAdapter.createApplication(
+        factory.applicant.build({ listingId: closedListing.data.id })
+      )
 
       const listings = await listingAdapter.getListingsWithApplicants({
         by: { type: 'historical' },
       })
       assert(listings.ok)
-
       expect(listings.data).toEqual([
         expect.objectContaining({ id: assignedListing.data.id }),
         expect.objectContaining({ id: closedListing.data.id }),

--- a/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/index.test.ts
@@ -51,7 +51,27 @@ describe('listing-adapter', () => {
       })
     })
 
-    it('allows duplicate combination of closed Listing statuses and RentalObjectCode', async () => {
+    it('allows duplicate combination of Listing status Assigned and RentalObjectCode', async () => {
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Assigned,
+        })
+      )
+
+      const insertionResult = await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Active,
+        })
+      )
+
+      expect(insertionResult).toMatchObject({
+        ok: true,
+      })
+    })
+
+    it('allows duplicate combination of Listing status Closed and RentalObjectCode', async () => {
       await listingAdapter.createListing(
         factory.listing.build({
           rentalObjectCode: '1',
@@ -62,7 +82,7 @@ describe('listing-adapter', () => {
       const insertionResult = await listingAdapter.createListing(
         factory.listing.build({
           rentalObjectCode: '1',
-          status: ListingStatus.Expired,
+          status: ListingStatus.Active,
         })
       )
 

--- a/src/services/lease-service/tests/offer-service.test.ts
+++ b/src/services/lease-service/tests/offer-service.test.ts
@@ -317,9 +317,7 @@ describe('denyOffer', () => {
     expect(updateOfferStatusSpy).toHaveBeenCalled()
     expect(res).toEqual({ ok: false, err: 'update-offer' })
 
-    const applicantFromDb = await listingAdapter.getApplicantById(
-      listing.data.id
-    )
+    const applicantFromDb = await listingAdapter.getApplicantById(applicant.id)
     expect(applicantFromDb?.status).toBe(applicant.status)
   })
 

--- a/src/services/lease-service/tests/sync-internal-parking-space-listings-from-xpand.test.ts
+++ b/src/services/lease-service/tests/sync-internal-parking-space-listings-from-xpand.test.ts
@@ -83,9 +83,7 @@ describe(service.syncInternalParkingSpaces, () => {
       await db('listing').select('rentalObjectCode')
     ).map((v) => v.rentalObjectCode)
 
-    expect(insertedListings).toEqual(
-      internalParkingSpaceMocks.map((v) => v.RentalObjectCode)
-    )
+    expect(insertedListings.length).toEqual(internalParkingSpaceMocks.length)
   })
 
   it('fails with error if fail to patch with residential data', async () => {


### PR DESCRIPTION
Part of https://linear.app/mimer-onecore/issue/UTH-125/inga-bilplatser-syns-i-historik-fliken

- Historical listings are listings that have had applicants and are either closed or assigned

We were only getting assigned listings when querying for 'historical' (and setting them to closed in onecore-core)

Also once again update the unique constraint for listings to accept duplicate rental object code on both closed and assigned listings. 
This is because both closed and assigned listings are considered "final"
