### PR TITLE
UTH-193 - ready-for-offer filter requires active applicants

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -15,7 +15,7 @@ jobs:
           ACCEPT_EULA: Y
         ports:
           - "1433:1433"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -287,6 +287,7 @@ const getListingsWithApplicants = async (
             SELECT 1
             FROM applicant a
             WHERE a.ListingId = l.Id
+            AND a.Status = ?
           )
           AND NOT EXISTS (
             SELECT 1
@@ -294,7 +295,7 @@ const getListingsWithApplicants = async (
             WHERE o.ListingId = l.Id
           )
           `,
-          [ListingStatus.Expired]
+          [ListingStatus.Expired, ApplicantStatus.Active]
         )
       )
       .with({ type: 'offered' }, () =>

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { ListingStatus, OfferStatus } from 'onecore-types'
+import { ApplicantStatus, ListingStatus, OfferStatus } from 'onecore-types'
 
 import * as listingAdapter from '../../../adapters/listing-adapter'
 import * as offerAdapter from '../../../adapters/offer-adapter'
@@ -371,6 +371,76 @@ describe(listingAdapter.getListingsWithApplicants, () => {
 
         expect(listings.data).toEqual([
           expect.objectContaining({ id: needsRepublishListing.data.id }),
+        ])
+      }))
+
+    it('ready-for-offer should not return listings whos applicants were removed', () =>
+      withContext(async (ctx) => {
+        const listing = await listingAdapter.createListing(
+          factory.listing.build({
+            rentalObjectCode: '1',
+            status: ListingStatus.Expired,
+          }),
+          ctx.db
+        )
+
+        assert(listing.ok)
+        const applicant = await listingAdapter.createApplication(
+          factory.applicant.build({ listingId: listing.data.id }),
+          ctx.db
+        )
+
+        assert(applicant)
+        await listingAdapter.updateApplicantStatus(
+          applicant.id,
+          ApplicantStatus.WithdrawnByUser,
+          ctx.db
+        )
+
+        const listings = await listingAdapter.getListingsWithApplicants(
+          ctx.db,
+          {
+            by: { type: 'ready-for-offer' },
+          }
+        )
+
+        assert(listings.ok)
+        expect(listings.data).toEqual([])
+      }))
+
+    it('needs-republish should return listings whos applicants were removed', () =>
+      withContext(async (ctx) => {
+        const listing = await listingAdapter.createListing(
+          factory.listing.build({
+            rentalObjectCode: '1',
+            status: ListingStatus.NoApplicants,
+          }),
+          ctx.db
+        )
+
+        assert(listing.ok)
+        const applicant = await listingAdapter.createApplication(
+          factory.applicant.build({ listingId: listing.data.id }),
+          ctx.db
+        )
+
+        assert(applicant)
+        await listingAdapter.updateApplicantStatus(
+          applicant.id,
+          ApplicantStatus.WithdrawnByUser,
+          ctx.db
+        )
+
+        const listings = await listingAdapter.getListingsWithApplicants(
+          ctx.db,
+          {
+            by: { type: 'needs-republish' },
+          }
+        )
+
+        assert(listings.ok)
+        expect(listings.data).toEqual([
+          expect.objectContaining({ id: listing.data.id }),
         ])
       }))
   })


### PR DESCRIPTION
https://linear.app/mimer-onecore/issue/UTH-193/fliken-klara-for-erbjudande-ska-inte-visa-annonser-vars-ansokningar