### PR TITLE
fix: parsing housing contracts 

### DIFF
--- a/src/services/lease-service/priority-list-service.ts
+++ b/src/services/lease-service/priority-list-service.ts
@@ -228,9 +228,14 @@ const parseLeasesForHousingContracts = (
   | undefined => {
   const currentDate = new Date()
   const housingContracts: Lease[] = []
+
   for (const lease of leases) {
-    //use startsWith to handle whitespace issues from xpand
-    if (lease.type.includes(leaseTypes.housingContract)) {
+    const isHousingContract = [
+      leaseTypes.housingContract,
+      leaseTypes.cooperativeTenancyContract,
+    ].some((v) => lease.type.includes(v))
+
+    if (isHousingContract) {
       housingContracts.push(lease)
     }
   }

--- a/src/services/lease-service/priority-list-service.ts
+++ b/src/services/lease-service/priority-list-service.ts
@@ -251,12 +251,12 @@ const parseLeasesForHousingContracts = (
 
   //applicant have 1 active and 1 upcoming contract
   if (housingContracts.length == 2) {
-    const currentActiveLease = leases.find((lease) => {
-      const lastDebitDateNotSet =
-        lease.lastDebitDate === null || lease.lastDebitDate === undefined
+    const currentActiveLease = housingContracts.find((lease) => {
+      const compatibleLastDebitDate =
+        !lease.lastDebitDate || lease.lastDebitDate > currentDate
       const hasLeaseStarted = lease.leaseStartDate <= currentDate
 
-      return lastDebitDateNotSet && hasLeaseStarted
+      return hasLeaseStarted && compatibleLastDebitDate
     })
 
     if (currentActiveLease == undefined) {
@@ -266,7 +266,7 @@ const parseLeasesForHousingContracts = (
       throw new Error('could not find any active lease')
     }
 
-    const upcomingLease = leases.find((lease) => {
+    const upcomingLease = housingContracts.find((lease) => {
       const lastDebitDateNotSet =
         lease.lastDebitDate === null || lease.lastDebitDate === undefined
       const isLeaseUpcoming = lease.leaseStartDate > currentDate


### PR DESCRIPTION
- In `parseLeasesForHousingContracts` after collecting the housing contract, we should operate only on that list and not on the incoming unfiltered list of leases. This was giving false positives in our tests.
- `parseLeasesForHousingContracts` when checking for active lease, we count as active if last debit date is set but in the future
- leasingTypes.cooperativeTenancyContract also counts as housing contract