### PR TITLE
UTH-209: Revise Application Profile and Reference table and schemas.

### DIFF
--- a/migrations/20250218133907_revise-application-profile.js
+++ b/migrations/20250218133907_revise-application-profile.js
@@ -23,6 +23,25 @@ exports.up = function (knex) {
       ALTER TABLE application_profile
       ADD lastUpdatedAt datetimeoffset;
     `)
+
+    await trx.raw(`
+      INSERT INTO application_profile_housing_reference (applicationProfileId, reviewStatus, createdAt)
+      SELECT 
+        ap.id as applicationProfileId,
+        'PENDING' as reviewStatus,
+        GETUTCDATE() as createdAt
+      FROM application_profile ap
+      WHERE NOT EXISTS (
+        SELECT 1 
+        FROM application_profile_housing_reference hr 
+        WHERE hr.applicationProfileId = ap.id
+      );
+    `)
+
+    await trx.raw(`
+      UPDATE application_profile
+      SET expiresAt = GETUTCDATE();
+    `)
   })
 }
 

--- a/migrations/20250218133907_revise-application-profile.js
+++ b/migrations/20250218133907_revise-application-profile.js
@@ -1,0 +1,60 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.transaction(async (trx) => {
+    await trx.raw(`
+       ALTER TABLE application_profile_housing_reference
+       DROP COLUMN
+         lastAdminUpdatedBy,
+         lastAdminUpdatedAt,
+         lastApplicantUpdatedAt;
+    `)
+
+    await trx.raw(`
+      ALTER TABLE application_profile_housing_reference
+      ADD 
+        reviewedAt datetimeoffset,
+        reviewedBy nvarchar(36);
+    `)
+
+    await trx.raw(`
+      ALTER TABLE application_profile
+      ADD lastUpdatedAt datetimeoffset;
+    `)
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.transaction(async (trx) => {
+    await trx.raw(`
+       ALTER TABLE application_profile_housing_reference
+       ADD
+         lastAdminUpdatedBy nvarchar(36),
+         lastAdminUpdatedAt datetimeoffset,
+         lastApplicantUpdatedAt datetimeoffset;
+    `)
+
+    await trx.raw(`
+       UPDATE application_profile_housing_reference
+       SET lastApplicantUpdatedAt = createdAt;
+    `)
+
+    await trx.raw(`
+      ALTER TABLE application_profile_housing_reference
+      DROP COLUMN
+        reviewedAt,
+        reviewedBy;
+    `)
+
+    await trx.raw(`
+      ALTER TABLE application_profile
+      DROP COLUMN lastUpdatedAt;
+    `)
+  })
+}

--- a/src/services/lease-service/adapters/application-profile-adapter.ts
+++ b/src/services/lease-service/adapters/application-profile-adapter.ts
@@ -18,6 +18,7 @@ const _CreateParamsSchema = ApplicationProfileSchema.pick({
   housingType: true,
   housingTypeDescription: true,
   landlord: true,
+  lastUpdatedAt: true,
 }).extend({
   housingReference: ApplicationProfileHousingReferenceSchema.pick({
     expiresAt: true,
@@ -26,8 +27,8 @@ const _CreateParamsSchema = ApplicationProfileSchema.pick({
     reviewStatus: true,
     comment: true,
     reasonRejected: true,
-    lastAdminUpdatedAt: true,
-    lastApplicantUpdatedAt: true,
+    reviewedAt: true,
+    reviewedBy: true,
   }),
 })
 
@@ -51,6 +52,7 @@ export async function create(
           housingType: params.housingType,
           housingTypeDescription: params.housingTypeDescription,
           landlord: params.landlord,
+          lastUpdatedAt: params.lastUpdatedAt,
         })
         .into('application_profile')
         .returning('*')
@@ -63,10 +65,8 @@ export async function create(
           reviewStatus: params.housingReference.reviewStatus,
           comment: params.housingReference.comment,
           reasonRejected: params.housingReference.reasonRejected,
-          lastAdminUpdatedAt: params.housingReference.lastAdminUpdatedAt,
-          lastAdminUpdatedBy: 'not-implemented',
-          lastApplicantUpdatedAt:
-            params.housingReference.lastApplicantUpdatedAt,
+          reviewedAt: params.housingReference.reviewedAt,
+          reviewedBy: 'not-implemented',
           expiresAt: params.housingReference.expiresAt,
         })
         .into('application_profile_housing_reference')
@@ -166,10 +166,8 @@ export async function update(
           reviewStatus: params.housingReference.reviewStatus,
           comment: params.housingReference.comment,
           reasonRejected: params.housingReference.reasonRejected,
-          lastAdminUpdatedAt: params.housingReference.lastAdminUpdatedAt,
-          lastAdminUpdatedBy: 'not-implemented',
-          lastApplicantUpdatedAt:
-            params.housingReference.lastApplicantUpdatedAt,
+          reviewedAt: params.housingReference.reviewedAt,
+
           expiresAt: params.housingReference.expiresAt,
         })
         .where({ applicationProfileId: profile.id })

--- a/src/services/lease-service/adapters/application-profile-adapter.ts
+++ b/src/services/lease-service/adapters/application-profile-adapter.ts
@@ -173,6 +173,13 @@ export async function update(
         .where({ applicationProfileId: profile.id })
         .returning('*')
 
+      if (!reference) {
+        logger.error(
+          `applicationProfileAdapter.update - no reference found for profile id ${profile.id}`
+        )
+        return 'missing-reference'
+      }
+
       return ApplicationProfileSchema.parse({
         ...profile,
         housingReference: reference,
@@ -181,6 +188,10 @@ export async function update(
 
     if (result === 'no-update') {
       return { ok: false, err: 'no-update' }
+    }
+
+    if (result === 'missing-reference') {
+      return { ok: false, err: 'unknown' }
     }
 
     return { ok: true, data: result }

--- a/src/services/lease-service/adapters/application-profile-adapter.ts
+++ b/src/services/lease-service/adapters/application-profile-adapter.ts
@@ -151,6 +151,7 @@ export async function update(
           housingType: params.housingType,
           housingTypeDescription: params.housingTypeDescription,
           landlord: params.landlord,
+          lastUpdatedAt: params.lastUpdatedAt,
         })
         .where('contactCode', contactCode)
         .returning('*')
@@ -167,7 +168,6 @@ export async function update(
           comment: params.housingReference.comment,
           reasonRejected: params.housingReference.reasonRejected,
           reviewedAt: params.housingReference.reviewedAt,
-
           expiresAt: params.housingReference.expiresAt,
         })
         .where({ applicationProfileId: profile.id })

--- a/src/services/lease-service/adapters/db-schemas.ts
+++ b/src/services/lease-service/adapters/db-schemas.ts
@@ -23,9 +23,8 @@ export const ApplicationProfileHousingReferenceSchema = z.object({
   reviewStatus: HousingReferenceReviewStatusSchema,
   comment: z.string().nullable(),
   reasonRejected: HousingReferenceReasonRejectedSchema.nullable(),
-  lastAdminUpdatedAt: z.coerce.date().nullable(),
-  lastAdminUpdatedBy: z.string().nullable(),
-  lastApplicantUpdatedAt: z.coerce.date().nullable(),
+  reviewedAt: z.coerce.date().nullable(),
+  reviewedBy: z.string().nullable(),
 
   expiresAt: z.union([z.null(), z.coerce.date()]),
   createdAt: z.coerce.date(),
@@ -51,6 +50,7 @@ export const ApplicationProfileSchema = z.object({
   housingTypeDescription: z.string().nullable(),
   landlord: z.string().nullable(),
   housingReference: ApplicationProfileHousingReferenceSchema,
-  expiresAt: z.coerce.date().nullable(),
+  expiresAt: z.union([z.null(), z.coerce.date()]),
   createdAt: z.coerce.date(),
+  lastUpdatedAt: z.union([z.null(), z.coerce.date()]),
 })

--- a/src/services/lease-service/tests/adapters/application-profile-adapter.test.ts
+++ b/src/services/lease-service/tests/adapters/application-profile-adapter.test.ts
@@ -16,6 +16,7 @@ describe('application-profile-adapter', () => {
           housingTypeDescription: 'bar',
           landlord: 'baz',
           housingReference: factory.applicationProfileHousingReference.build(),
+          lastUpdatedAt: new Date(),
         })
         assert(profile.ok)
 
@@ -38,6 +39,7 @@ describe('application-profile-adapter', () => {
           housingTypeDescription: 'bar',
           landlord: 'baz',
           housingReference: factory.applicationProfileHousingReference.build(),
+          lastUpdatedAt: new Date(),
         })
 
         assert(profile.ok)
@@ -54,6 +56,7 @@ describe('application-profile-adapter', () => {
             landlord: 'baz',
             housingReference:
               factory.applicationProfileHousingReference.build(),
+            lastUpdatedAt: new Date(),
           }
         )
 
@@ -84,6 +87,8 @@ describe('application-profile-adapter', () => {
           housingTypeDescription: 'bar',
           landlord: 'baz',
           housingReference: factory.applicationProfileHousingReference.build(),
+
+          lastUpdatedAt: new Date(),
         })
 
         const result = await applicationProfileAdapter.getByContactCode(
@@ -120,6 +125,7 @@ describe('application-profile-adapter', () => {
             landlord: 'baz',
             housingReference:
               factory.applicationProfileHousingReference.build(),
+            lastUpdatedAt: new Date(),
           }
         )
 
@@ -136,6 +142,7 @@ describe('application-profile-adapter', () => {
           housingTypeDescription: 'bar',
           landlord: 'baz',
           housingReference: factory.applicationProfileHousingReference.build(),
+          lastUpdatedAt: new Date(),
         })
 
         assert(profile.ok)
@@ -151,6 +158,7 @@ describe('application-profile-adapter', () => {
             landlord: 'baz',
             housingReference:
               factory.applicationProfileHousingReference.build(),
+            lastUpdatedAt: new Date(),
           }
         )
 

--- a/src/services/lease-service/tests/factories/application-profile.ts
+++ b/src/services/lease-service/tests/factories/application-profile.ts
@@ -19,6 +19,7 @@ export const ApplicationProfileFactory = Factory.define<ApplicationProfile>(
     createdAt: new Date(),
     expiresAt: new Date(),
     housingReference: ApplicationProfileHousingReferenceFactory.build(),
+    lastUpdatedAt: new Date(),
   })
 )
 
@@ -30,9 +31,8 @@ export const ApplicationProfileHousingReferenceFactory =
     phone: 'phone',
     reviewStatus: 'PENDING',
     comment: 'comment',
-    lastAdminUpdatedAt: null,
-    lastAdminUpdatedBy: 'foo',
-    lastApplicantUpdatedAt: new Date(),
+    reviewedAt: null,
+    reviewedBy: 'foo',
     reasonRejected: null,
 
     expiresAt: new Date(),

--- a/src/services/lease-service/tests/routes/contacts.test.ts
+++ b/src/services/lease-service/tests/routes/contacts.test.ts
@@ -206,6 +206,7 @@ describe('POST /contacts/:contactCode/application-profile', () => {
         housingTypeDescription: null,
         landlord: null,
         housingReference: factories.applicationProfileHousingReference.build(),
+        lastUpdatedAt: new Date(),
       })
 
     expect(res.status).toBe(200)
@@ -234,6 +235,7 @@ describe('POST /contacts/:contactCode/application-profile', () => {
         housingTypeDescription: null,
         landlord: null,
         housingReference: factories.applicationProfileHousingReference.build(),
+        lastUpdatedAt: new Date(),
       })
 
     expect(res.status).toBe(201)

--- a/src/services/lease-service/tests/update-or-create-application-profile.test.ts
+++ b/src/services/lease-service/tests/update-or-create-application-profile.test.ts
@@ -16,12 +16,13 @@ describe(updateOrCreateApplicationProfile.name, () => {
           housingType: 'RENTAL',
           landlord: 'baz',
           housingTypeDescription: 'qux',
+          lastUpdatedAt: new Date(),
           housingReference: {
             comment: null,
             email: null,
             expiresAt: new Date(),
-            lastAdminUpdatedAt: null,
-            lastApplicantUpdatedAt: new Date(),
+            reviewedAt: null,
+            reviewedBy: null,
             phone: null,
             reasonRejected: null,
             reviewStatus: 'PENDING',
@@ -65,6 +66,7 @@ describe(updateOrCreateApplicationProfile.name, () => {
             housingType: 'RENTAL',
             landlord: 'quux',
             housingTypeDescription: 'corge',
+            lastUpdatedAt: new Date(),
             housingReference: {
               ...existingProfile.data.housingReference,
               email: 'bar',


### PR DESCRIPTION
https://linear.app/mimer-onecore/issue/UTH-209/boendereferens-andringar

- Adds a migration that adds an "empty" application profile housing reference row for every application profile we have.
  Housing reference is now a non-nullable property on the application profile. We also expire all existing profiles in this migration so users should have to update their information