### PR TITLE
Added filter to remove deleted invoices since they break transformFromDb

### DIFF
--- a/src/services/lease-service/adapters/xpand/invoices-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/invoices-adapter.ts
@@ -79,7 +79,15 @@ const getInvoicesByContactCode = async (
     .orderBy('krfkh.fromdate', 'desc')
   if (rows && rows.length > 0) {
     const invoices: Invoice[] = rows
-      .filter((row) => row.invoiceId)
+      .filter((row) => {
+        // Only include invoices with invoiceIds
+        // that have not been deleted (debitStatus 6 = makulerad)
+        if (row.invoiceId && row.debitStatus !== 6) {
+          return true
+        } else {
+          return false
+        }
+      })
       .map(transformFromDbInvoice)
     logger.info(
       { contactCode: contactKey },

--- a/src/services/lease-service/routes/invoices.ts
+++ b/src/services/lease-service/routes/invoices.ts
@@ -1,5 +1,5 @@
 import KoaRouter from '@koa/router'
-import { generateRouteMetadata } from 'onecore-utilities'
+import { generateRouteMetadata, logger } from 'onecore-utilities'
 
 import * as invoicesAdapter from '../adapters/xpand/invoices-adapter'
 
@@ -44,13 +44,18 @@ export const routes = (router: KoaRouter) => {
    */
   router.get('(.*)/contact/invoices/contactCode/:contactCode', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const responseData = await invoicesAdapter.getInvoicesByContactCode(
-      ctx.params.contactCode
-    )
+    try {
+      const responseData = await invoicesAdapter.getInvoicesByContactCode(
+        ctx.params.contactCode
+      )
 
-    ctx.body = {
-      content: responseData,
-      ...metadata,
+      ctx.body = {
+        content: responseData,
+        ...metadata,
+      }
+    } catch (error) {
+      logger.error(error, 'Error getting invoices by contact code')
+      throw error
     }
   })
 


### PR DESCRIPTION
Invoices that have been deleted get leaseId = null, which breaks our types and transformFromDb which assumes a non-null leaseId at all times.

Marking invoices as deleted ('makulerad') are a way to get rid of invoices that could not actually been deleted.