### PR TITLE
Feat: UTH-214 New Rules of Current Housing Contract

### DIFF
--- a/src/services/lease-service/priority-list-service.ts
+++ b/src/services/lease-service/priority-list-service.ts
@@ -218,7 +218,6 @@ const isLeaseActiveOrUpcoming = (lease: Lease): boolean => {
   )
 }
 
-//this function is based on xpand rules that there can be max 1 current active contract and 1 upcoming contract
 const parseLeasesForHousingContracts = (
   leases: Lease[]
 ):
@@ -240,49 +239,23 @@ const parseLeasesForHousingContracts = (
     return undefined
   }
 
-  if (housingContracts.length === 1) {
-    const lease = housingContracts[0]
-    const hasLeaseStarted = lease.leaseStartDate <= currentDate
+  const activeLease = housingContracts.find((l) =>
+    isCurrentLease(l, currentDate)
+  )
 
-    //if lease has started we have an active contract, otherwise an upcoming contract
-    return hasLeaseStarted ? [lease, undefined] : [undefined, lease]
-  }
+  const upcomingLease = housingContracts.find((l) =>
+    isUpcomingLease(l, currentDate)
+  )
 
-  if (housingContracts.length === 2) {
-    const activeLease = housingContracts.find((l) =>
-      isActiveLease(l, currentDate)
-    )
-
-    const upcomingLease = housingContracts.find((l) =>
-      isUpcomingLease(l, currentDate)
-    )
-
-    if (!activeLease) {
-      logger.error(
-        'Could not find active lease in parseLeasesForHousingContracts'
-      )
-
-      throw new Error('could not find any active lease')
-    }
-
-    if (upcomingLease == undefined) {
-      logger.error(
-        'Could not find any pending lease in parseLeasesForHousingContracts'
-      )
-
-      throw new Error('Could not find any pending lease')
-    }
-
-    return [activeLease, upcomingLease]
-  }
+  return [activeLease, upcomingLease]
 }
 
-const isActiveLease = (lease: Lease, currentDate: Date) => {
-  const compatibleLastDebitDate =
-    !lease.lastDebitDate || lease.lastDebitDate > currentDate
+const isCurrentLease = (lease: Lease, currentDate: Date) => {
+  const lastDebitDateNotSet =
+    lease.lastDebitDate === null || lease.lastDebitDate === undefined
   const hasLeaseStarted = lease.leaseStartDate <= currentDate
 
-  return hasLeaseStarted && compatibleLastDebitDate
+  return hasLeaseStarted && lastDebitDateNotSet
 }
 const isUpcomingLease = (lease: Lease, currentDate: Date) => {
   const lastDebitDateNotSet =

--- a/src/services/lease-service/tests/priority-list-service.test.ts
+++ b/src/services/lease-service/tests/priority-list-service.test.ts
@@ -155,7 +155,7 @@ describe('parseLeasesForHousingContract', () => {
   })
 
   it("shouldn't choose a housing contract that is about to end as currentHousingContract", async () => {
-    let currentDate = new Date()
+    const currentDate = new Date()
     const soonToBeTerminatedHousingContract = factory.lease
       .params({
         leaseId: '211-141-02-1005/02',

--- a/src/services/lease-service/tests/priority-list-service.test.ts
+++ b/src/services/lease-service/tests/priority-list-service.test.ts
@@ -71,7 +71,7 @@ describe('parseLeasesForHousingContract', () => {
     }
   })
 
-  it('should return 1 active housing contract and 1 upcoming housing contract', async () => {
+  it('should return 1 upcoming housing contract', async () => {
     const soonToBeTerminatedHousingContract = factory.lease
       .params({
         type: leaseTypes.housingContract,
@@ -119,12 +119,8 @@ describe('parseLeasesForHousingContract', () => {
 
     expect(filteredLeases).toHaveLength(3)
     assert(result)
-    const [current, upcoming] = result
 
-    assert(current)
-    assert(upcoming)
-
-    expect(result[0]).toBeDefined()
+    expect(result[0]).toBeUndefined()
     expect(result[1]).toBeDefined()
   })
 
@@ -156,6 +152,80 @@ describe('parseLeasesForHousingContract', () => {
   it('should return undefined for leases without housing contract', async () => {
     const result = parseLeasesForHousingContracts([])
     expect(result).toBeUndefined()
+  })
+
+  it("shouldn't choose a housing contract that is about to end as currentHousingContract", async () => {
+    let currentDate = new Date()
+    const soonToBeTerminatedHousingContract = factory.lease
+      .params({
+        leaseId: '211-141-02-1005/02',
+        leaseNumber: '02',
+        rentalPropertyId: '211-141-02-1005',
+        type: 'Bostadskontrakt               ',
+        leaseStartDate: new Date('2024-07-01T00:00:00.000Z'),
+        leaseEndDate: undefined,
+        status: 2,
+        tenantContactIds: [],
+        tenants: [],
+        rentalProperty: undefined,
+        rentInfo: undefined,
+        address: undefined,
+        noticeGivenBy: 'G',
+        noticeDate: new Date('2024-11-21T00:00:00.000Z'),
+        noticeTimeTenant: '3',
+        preferredMoveOutDate: new Date('2025-01-31T00:00:00.000Z'),
+        terminationDate: undefined,
+        contractDate: new Date('2024-04-10T00:00:00.000Z'),
+        lastDebitDate: new Date(
+          currentDate.getFullYear(),
+          currentDate.getMonth(),
+          currentDate.getDate() + 3
+        ),
+        approvalDate: new Date('2024-04-10T00:00:00.000Z'),
+        residentialArea: { code: 'BÄC', caption: 'Bäckby' },
+      })
+      .build()
+
+    const anotherActiveHousingContract = factory.lease
+      .params({
+        leaseId: '102-003-01-0403/08',
+        leaseNumber: '08',
+        rentalPropertyId: '102-003-01-0403',
+        type: 'Bostadskontrakt               ',
+        leaseStartDate: new Date('2025-02-01T00:00:00.000Z'),
+        leaseEndDate: undefined,
+        status: 0,
+        tenantContactIds: [],
+        tenants: [],
+        rentalProperty: undefined,
+        rentInfo: undefined,
+        address: undefined,
+        noticeGivenBy: undefined,
+        noticeDate: undefined,
+        noticeTimeTenant: '3',
+        preferredMoveOutDate: undefined,
+        terminationDate: undefined,
+        contractDate: new Date('2024-11-21T00:00:00.000Z'),
+        lastDebitDate: undefined,
+        approvalDate: new Date('2024-11-21T00:00:00.000Z'),
+        residentialArea: { code: 'CEN', caption: 'Centrum' },
+      })
+      .build()
+
+    const leases = [
+      soonToBeTerminatedHousingContract,
+      anotherActiveHousingContract,
+    ]
+
+    const filteredLeases: Lease[] = leases.filter(isLeaseActiveOrUpcoming)
+    const result = parseLeasesForHousingContracts(filteredLeases)
+
+    expect(filteredLeases).toHaveLength(2)
+    assert(result)
+    const [current, upcoming] = result
+
+    expect(current?.leaseId).toBe('102-003-01-0403/08')
+    expect(upcoming).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
* Added condition that lastDebitDate should be null or undefined
* No longer throwing errors if currentHousingContract or upcomingHousingContract is not found