### PR TITLE
Feat: UTH-212 Parking Spaces for Secret Identities

### DIFF
--- a/migrations/20250325075550_make-name-and-nationalRegistrationNumber-nullable-for-applicant.js
+++ b/migrations/20250325075550_make-name-and-nationalRegistrationNumber-nullable-for-applicant.js
@@ -1,0 +1,39 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable('applicant', function (table) {
+    table.string('NationalRegistrationNumber').defaultTo(null).alter()
+  })
+
+  return knex.schema.alterTable('applicant', function (table) {
+    table.string('Name').nullable().alter()
+    table.string('NationalRegistrationNumber').nullable().alter()
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  // Remove the index before dropping the column so that it doesn't cause an error to set it to notNullable
+  await knex.schema.alterTable('applicant', function (table) {
+    table.dropIndex('NationalRegistrationNumber')
+  })
+
+  await knex.schema.alterTable('applicant', function (table) {
+    table.string('Name').notNullable().alter()
+    table
+      .string('NationalRegistrationNumber')
+      .notNullable()
+      .defaultTo('00000000-0000')
+      .alter()
+  })
+
+  //Re-add the index
+  return knex.schema.alterTable('applicant', function (table) {
+    table.index('NationalRegistrationNumber')
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6738,6 +6738,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/knex/-/knex-2.5.1.tgz",
       "integrity": "sha512-z78DgGKUr4SE/6cm7ku+jHvFT0X97aERh/f0MUKAKgFnwCYBEW4TFBqtHWFYiJFid7fMrtpZ/gxJthvz5mEByA==",
+      "license": "MIT",
       "dependencies": {
         "colorette": "2.0.19",
         "commander": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa2-swagger-ui": "^5.10.0",
         "mssql": "^11.0.1",
-        "onecore-types": "^3.6.0",
+        "onecore-types": "^3.7.1",
         "onecore-utilities": "^1.1.0",
         "personnummer": "^3.2.1",
         "pino": "^9.1.0",
@@ -7561,9 +7561,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.6.0.tgz",
-      "integrity": "sha512-+zg8yO16tFzQzxWZ/hiX6rk9WFElwyjE+bbJTd7pzJlu78KGgE/pZ9tSpP2R64ptyQ33ueikT3F1Xm2d1LacCg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.7.1.tgz",
+      "integrity": "sha512-2Gn+6HAm9N8SXqLABkxn5wC9X3hYbUmDzHt/bj6AGwsMVP94gKEjF5ZvSchNyJ5CsVLM0GZ/IFslfYygHHxhGg==",
       "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa2-swagger-ui": "^5.10.0",
     "mssql": "^11.0.1",
-    "onecore-types": "^3.6.0",
+    "onecore-types": "^3.7.1",
     "onecore-utilities": "^1.1.0",
     "personnummer": "^3.2.1",
     "pino": "^9.1.0",

--- a/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
@@ -130,7 +130,7 @@ const getLeasesForNationalRegistrationNumber = async (
     })
     .limit(1)
 
-  if (contact != undefined) {
+  if (contact != undefined && contact.length > 0) {
     const leases = await getLeasesByContactKey(contact[0].contactKey)
 
     logger.info(

--- a/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
@@ -137,7 +137,7 @@ const getLeasesForNationalRegistrationNumber = async (
     .limit(1)
 
   if (contact != undefined && contact.length > 0) {
-    const leases = await getLeasesByContactKey(contact[0].contactKey)
+    let leases = await getLeasesByContactKey(contact[0].contactKey)
 
     logger.info(
       'Getting leases for national registration number from Xpand DB complete'

--- a/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -158,8 +158,6 @@ const addToWaitingList = async (
   }
 }
 
-//TODO: testa att hämta, lägga till och ta bort från kö utan att skicka med personnummer
-//TODO 2: Testa hela flödet med användare utan personnummer både från medarbetarportalen och Mimer.nu
 const removeApplicantFromWaitingList = async (
   contactCode: string,
   waitingListType: WaitingListType

--- a/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -113,10 +113,6 @@ const addApplicantToToWaitingList = async (
     `Add to Waiting list type ${waitingListType} not implemented yet`
   )
   return { ok: false, err: 'waiting-list-type-not-implemented' }
-  // throw createHttpError(
-  //   500,
-  //   `Add to Waiting list type ${waitingListType} not implemented yet`
-  // )
 }
 
 const addToWaitingList = async (
@@ -167,16 +163,11 @@ const addToWaitingList = async (
         `Add to waiting list failed for ${waitingListTypeCaption}: ${parsedResponse['Message']}`
       )
       return { ok: false, err: 'already-in-waiting-list' }
-      // throw createHttpError(409, 'Applicant already in waiting list')
     } else {
       logger.error(
         `Add to waiting list failed with unknown error for ${waitingListTypeCaption}: ${parsedResponse['Message']}`
       )
       return { ok: false, err: 'unknown' }
-      // throw createHttpError(
-      //   500,
-      //   `unknown error when adding applicant to waiting list: ${parsedResponse['Message']}`
-      // )
     }
   } catch (error) {
     logger.error(

--- a/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -88,25 +88,46 @@ const createLease = async (
 const addApplicantToToWaitingList = async (
   contactCode: string,
   waitingListType: WaitingListType.ParkingSpace
-) => {
+): Promise<
+  AdapterResult<
+    undefined,
+    'already-in-waiting-list' | 'unknown' | 'waiting-list-type-not-implemented'
+  >
+> => {
   if (waitingListType == WaitingListType.ParkingSpace) {
-    await addToWaitingList(contactCode, 'Bilplats (intern)')
-    await addToWaitingList(contactCode, 'Bilplats (extern)')
-    return
+    const resultInternalParkingSpace = await addToWaitingList(
+      contactCode,
+      'Bilplats (intern)'
+    )
+    const resultExternalParkingSpace = await addToWaitingList(
+      contactCode,
+      'Bilplats (extern)'
+    )
+
+    if (resultInternalParkingSpace.ok && resultExternalParkingSpace.ok)
+      return { ok: true, data: undefined }
+    if (!resultInternalParkingSpace.ok) return resultInternalParkingSpace
+    if (!resultExternalParkingSpace.ok) return resultExternalParkingSpace
   }
   logger.error(
     `Add to Waiting list type ${waitingListType} not implemented yet`
   )
-  throw createHttpError(
-    500,
-    `Add to Waiting list type ${waitingListType} not implemented yet`
-  )
+  return { ok: false, err: 'waiting-list-type-not-implemented' }
+  // throw createHttpError(
+  //   500,
+  //   `Add to Waiting list type ${waitingListType} not implemented yet`
+  // )
 }
 
 const addToWaitingList = async (
   contactCode: string,
   waitingListTypeCaption: string
-) => {
+): Promise<
+  AdapterResult<
+    undefined,
+    'already-in-waiting-list' | 'unknown' | 'waiting-list-type-not-implemented'
+  >
+> => {
   const headers = getHeaders()
 
   const xml = `
@@ -140,39 +161,61 @@ const addToWaitingList = async (
     const parsedResponse = parser.parse(body)['Envelope']['Body']['ResultBase']
 
     if (parsedResponse.Success) {
-      return
+      return { ok: true, data: undefined }
     } else if (parsedResponse['Message'] == 'Kötyp finns redan') {
-      throw createHttpError(409, 'Applicant already in waiting list')
-    } else {
-      throw createHttpError(
-        500,
-        `unknown error when adding applicant to waiting list: ${parsedResponse['Message']}`
+      logger.error(
+        `Add to waiting list failed for ${waitingListTypeCaption}: ${parsedResponse['Message']}`
       )
+      return { ok: false, err: 'already-in-waiting-list' }
+      // throw createHttpError(409, 'Applicant already in waiting list')
+    } else {
+      logger.error(
+        `Add to waiting list failed with unknown error for ${waitingListTypeCaption}: ${parsedResponse['Message']}`
+      )
+      return { ok: false, err: 'unknown' }
+      // throw createHttpError(
+      //   500,
+      //   `unknown error when adding applicant to waiting list: ${parsedResponse['Message']}`
+      // )
     }
   } catch (error) {
     logger.error(
       error,
-      'Error adding applicant to waitinglist using Xpand SOAP API'
+      'Error adding applicant to waitinglist using Xpand SOAP API for list ' +
+        waitingListTypeCaption
     )
-    throw error
+    return { ok: false, err: 'unknown' }
   }
 }
 
 const removeApplicantFromWaitingList = async (
   contactCode: string,
   waitingListType: WaitingListType
-): Promise<AdapterResult<undefined, 'not-in-waiting-list' | 'unknown'>> => {
+): Promise<
+  AdapterResult<
+    undefined,
+    'not-in-waiting-list' | 'unknown' | 'waiting-list-type-not-implemented'
+  >
+> => {
   if (waitingListType == WaitingListType.ParkingSpace) {
-    await removeFromWaitingList(contactCode, 'Bilplats (intern)')
-    return await removeFromWaitingList(contactCode, 'Bilplats (extern)')
+    const resultInternalParkingSpace = await removeFromWaitingList(
+      contactCode,
+      'Bilplats (intern)'
+    )
+    const resultExternalParkingSpace = await removeFromWaitingList(
+      contactCode,
+      'Bilplats (extern)'
+    )
+
+    if (resultInternalParkingSpace.ok && resultExternalParkingSpace.ok)
+      return { ok: true, data: undefined }
+    if (!resultInternalParkingSpace.ok) return resultInternalParkingSpace
+    if (!resultExternalParkingSpace.ok) return resultExternalParkingSpace
   }
   logger.error(
     `Remove from Waiting list type ${waitingListType} not implemented yet`
   )
-  throw createHttpError(
-    500,
-    `Remove from Waiting list type ${waitingListType} not implemented yet`
-  )
+  return { ok: false, err: 'waiting-list-type-not-implemented' }
 }
 const removeFromWaitingList = async (
   contactCode: string,
@@ -211,15 +254,24 @@ const removeFromWaitingList = async (
     const parsedResponse = parser.parse(body)['Envelope']['Body']['ResultBase']
 
     if (parsedResponse.Success) return { ok: true, data: undefined }
-    else if (parsedResponse['Message'] == 'Kötid saknas')
+    else if (parsedResponse['Message'] == 'Kötid saknas') {
+      logger.error(
+        `Remove from waiting list failed for ${waitingListTypeCaption}: ${parsedResponse['Message']}`
+      )
       return { ok: false, err: 'not-in-waiting-list' }
-    else return { ok: false, err: 'unknown' }
+    } else {
+      logger.error(
+        `Remove from waiting list failed with unkown error ${waitingListTypeCaption}: ${parsedResponse['Message']}`
+      )
+      return { ok: false, err: 'unknown' }
+    }
   } catch (error) {
     logger.error(
       error,
-      'Error adding applicant to waitinglist using Xpand SOAP API'
+      'Error removing applicant from waitinglist using Xpand SOAP API. waitingListTypeCaption: ' +
+        waitingListTypeCaption
     )
-    throw error
+    return { ok: false, err: 'unknown' }
   }
 }
 

--- a/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -86,21 +86,12 @@ const createLease = async (
 }
 
 const addApplicantToToWaitingList = async (
-  nationalRegistrationNumber: string,
   contactCode: string,
   waitingListType: WaitingListType.ParkingSpace
 ) => {
   if (waitingListType == WaitingListType.ParkingSpace) {
-    await addToWaitingList(
-      nationalRegistrationNumber,
-      contactCode,
-      'Bilplats (intern)'
-    )
-    await addToWaitingList(
-      nationalRegistrationNumber,
-      contactCode,
-      'Bilplats (extern)'
-    )
+    await addToWaitingList(contactCode, 'Bilplats (intern)')
+    await addToWaitingList(contactCode, 'Bilplats (extern)')
     return
   }
   logger.error(
@@ -113,7 +104,6 @@ const addApplicantToToWaitingList = async (
 }
 
 const addToWaitingList = async (
-  nationalRegistrationNumber: string,
   contactCode: string,
   waitingListTypeCaption: string
 ) => {
@@ -124,7 +114,6 @@ const addToWaitingList = async (
    <soap:Header xmlns:wsa='http://www.w3.org/2005/08/addressing'><wsa:Action>http://incit.xpand.eu/service/AddApplicantWaitingListTime/AddApplicantWaitingListTime</wsa:Action><wsa:To>${Config.xpandSoap.url}</wsa:To></soap:Header>
      <soap:Body>
         <ser:AddApplicantWaitingListTimeRequest>
-        <inc:CivicNumber>${nationalRegistrationNumber}</inc:CivicNumber>
         <inc:Code>${contactCode}</inc:Code>
         <inc:CompanyCode>001</inc:CompanyCode>
         <inc:MessageCulture>${Config.xpandSoap.messageCulture}</inc:MessageCulture>
@@ -169,22 +158,15 @@ const addToWaitingList = async (
   }
 }
 
+//TODO: testa att hämta, lägga till och ta bort från kö utan att skicka med personnummer
+//TODO 2: Testa hela flödet med användare utan personnummer både från medarbetarportalen och Mimer.nu
 const removeApplicantFromWaitingList = async (
-  nationalRegistrationNumber: string,
   contactCode: string,
   waitingListType: WaitingListType
 ): Promise<AdapterResult<undefined, 'not-in-waiting-list' | 'unknown'>> => {
   if (waitingListType == WaitingListType.ParkingSpace) {
-    await removeFromWaitingList(
-      nationalRegistrationNumber,
-      contactCode,
-      'Bilplats (intern)'
-    )
-    return await removeFromWaitingList(
-      nationalRegistrationNumber,
-      contactCode,
-      'Bilplats (extern)'
-    )
+    await removeFromWaitingList(contactCode, 'Bilplats (intern)')
+    return await removeFromWaitingList(contactCode, 'Bilplats (extern)')
   }
   logger.error(
     `Remove from Waiting list type ${waitingListType} not implemented yet`
@@ -195,7 +177,6 @@ const removeApplicantFromWaitingList = async (
   )
 }
 const removeFromWaitingList = async (
-  nationalRegistrationNumber: string,
   contactCode: string,
   waitingListTypeCaption: string
 ): Promise<AdapterResult<undefined, 'not-in-waiting-list' | 'unknown'>> => {
@@ -206,7 +187,6 @@ const removeFromWaitingList = async (
    <soap:Header xmlns:wsa='http://www.w3.org/2005/08/addressing'><wsa:Action>http://incit.xpand.eu/service/RemoveApplicantWaitingListTime/RemoveApplicantWaitingListTime</wsa:Action><wsa:To>${Config.xpandSoap.url}</wsa:To></soap:Header>
      <soap:Body>
         <ser:RemoveApplicantWaitingListTimeRequest>
-          <inc:CivicNumber>${nationalRegistrationNumber}</inc:CivicNumber>
           <inc:Code>${contactCode}</inc:Code>
           <inc:CompanyCode>001</inc:CompanyCode>
           <inc:MessageCulture>${Config.xpandSoap.messageCulture}</inc:MessageCulture>

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -91,8 +91,8 @@ export const routes = (router: KoaRouter) => {
   })
 
   const CreateApplicantRequestParamsSchema = z.object({
-    name: z.string(),
-    nationalRegistrationNumber: z.string(),
+    name: z.string().optional(),
+    nationalRegistrationNumber: z.string().optional(),
     contactCode: z.string(),
     applicationDate: z.coerce.date(),
     applicationType: z.string().optional(),

--- a/src/services/lease-service/tests/routes/contacts.test.ts
+++ b/src/services/lease-service/tests/routes/contacts.test.ts
@@ -77,13 +77,13 @@ describe('GET /contacts/search', () => {
       })
     })
 
-    it('returns status 404 upon not-in-waiting-list error from removeApplicantFromWaitingList', async () => {
+    it('returns status 200 upon not-in-waiting-list error from removeApplicantFromWaitingList', async () => {
       jest
         .spyOn(xPandSoapAdapter, 'removeApplicantFromWaitingList')
         .mockResolvedValue({ ok: false, err: 'not-in-waiting-list' })
       jest
         .spyOn(xPandSoapAdapter, 'addApplicantToToWaitingList')
-        .mockResolvedValue()
+        .mockResolvedValue({ ok: true, data: undefined })
 
       const res = await request(app.callback())
         .post('/contacts/1234567890/waitingLists/reset')
@@ -92,10 +92,7 @@ describe('GET /contacts/search', () => {
           waitingListType: WaitingListType.ParkingSpace,
         })
 
-      expect(res.status).toBe(404)
-      expect(res.body).toEqual({
-        error: 'Contact Not In Waiting List',
-      })
+      expect(res.status).toBe(200)
     })
 
     it('returns status 404 upon waiting-list-type-not-implemented error from removeApplicantFromWaitingList', async () => {
@@ -107,7 +104,10 @@ describe('GET /contacts/search', () => {
         })
       jest
         .spyOn(xPandSoapAdapter, 'addApplicantToToWaitingList')
-        .mockResolvedValue()
+        .mockResolvedValue({
+          ok: false,
+          err: 'waiting-list-type-not-implemented',
+        })
 
       const res = await request(app.callback())
         .post('/contacts/1234567890/waitingLists/reset')
@@ -128,7 +128,7 @@ describe('GET /contacts/search', () => {
         .mockResolvedValue({ ok: false, err: 'unknown' })
       jest
         .spyOn(xPandSoapAdapter, 'addApplicantToToWaitingList')
-        .mockResolvedValue()
+        .mockResolvedValue({ ok: true, data: undefined })
 
       const res = await request(app.callback())
         .post('/contacts/1234567890/waitingLists/reset')

--- a/src/services/lease-service/tests/routes/contacts.test.ts
+++ b/src/services/lease-service/tests/routes/contacts.test.ts
@@ -60,7 +60,7 @@ describe('GET /contacts/search', () => {
         .mockResolvedValue({ ok: true, data: undefined })
       jest
         .spyOn(xPandSoapAdapter, 'addApplicantToToWaitingList')
-        .mockResolvedValue()
+        .mockResolvedValue({ ok: true, data: undefined })
 
       const res = await request(app.callback())
         .post('/contacts/1234567890/waitingLists/reset')
@@ -95,6 +95,30 @@ describe('GET /contacts/search', () => {
       expect(res.status).toBe(404)
       expect(res.body).toEqual({
         error: 'Contact Not In Waiting List',
+      })
+    })
+
+    it('returns status 404 upon waiting-list-type-not-implemented error from removeApplicantFromWaitingList', async () => {
+      jest
+        .spyOn(xPandSoapAdapter, 'removeApplicantFromWaitingList')
+        .mockResolvedValue({
+          ok: false,
+          err: 'waiting-list-type-not-implemented',
+        })
+      jest
+        .spyOn(xPandSoapAdapter, 'addApplicantToToWaitingList')
+        .mockResolvedValue()
+
+      const res = await request(app.callback())
+        .post('/contacts/1234567890/waitingLists/reset')
+        .send({
+          contactCode: '123',
+          waitingListType: WaitingListType.ParkingSpace,
+        })
+
+      expect(res.status).toBe(404)
+      expect(res.body).toEqual({
+        error: 'Waiting List Type not Implemented',
       })
     })
 

--- a/src/services/lease-service/tests/waiting-list.test.ts
+++ b/src/services/lease-service/tests/waiting-list.test.ts
@@ -17,7 +17,7 @@ describe('POST contacts/1234567890/waitingList', () => {
   it('should return success', async () => {
     const xpandAdapterSpy = jest
       .spyOn(xpandSoapAdapter, 'addApplicantToToWaitingList')
-      .mockResolvedValue()
+      .mockResolvedValue({ ok: true, data: undefined })
 
     const result = await request(app.callback()).post(
       '/contacts/1234567890/waitingLists'
@@ -27,7 +27,19 @@ describe('POST contacts/1234567890/waitingList', () => {
     expect(result.status).toEqual(201)
   })
 
-  it('handles errors', async () => {
+  it('handles unknown errors', async () => {
+    const xpandAdapterSpy = jest
+      .spyOn(xpandSoapAdapter, 'addApplicantToToWaitingList')
+      .mockResolvedValue({ ok: false, err: 'unknown' })
+
+    const result = await request(app.callback()).post(
+      '/contacts/1234567890/waitingLists'
+    )
+
+    expect(xpandAdapterSpy).toHaveBeenCalled()
+    expect(result.status).toEqual(HttpStatusCode.InternalServerError)
+  })
+  it('handles unhandled errors', async () => {
     const xpandAdapterSpy = jest
       .spyOn(xpandSoapAdapter, 'addApplicantToToWaitingList')
       .mockImplementation(() => {


### PR DESCRIPTION
A contact with secret identity should be able to rent an internal parking space. A contact with a secret identity doesn't have name or national security number set

* Enable null for name and pnr on applicant in the database and schemas
* Get and reset wailing lists on contact code instead of national security number