### PR TITLE
Feat: UTH-245 Add Endpoint to Get Listings

### DIFF
--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -285,9 +285,7 @@ const getListings = async (
       }
     })
 
-    const transformedListings = listings.map(transformFromDbListing)
-
-    return { ok: true, data: transformedListings }
+    return { ok: true, data: listings.map(transformFromDbListing) }
   } catch (err) {
     logger.error(err, 'listingAdapter.getListings')
     return { ok: false, err: 'unknown' }

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -265,7 +265,6 @@ const updateApplicantStatus = async (
   }
 }
 
-//todo: varför tar alla metoder dbConnection? Är det för att kunna göra tester som går mot riktiga db? Konsekvensen blir att adaptern inte är utbytbar/oberoende mot servicen...
 const getListings = async (
   published?: boolean,
   rentalRule?: 'Scored' | 'NonScored',

--- a/src/services/lease-service/adapters/listing-adapter.ts
+++ b/src/services/lease-service/adapters/listing-adapter.ts
@@ -273,7 +273,7 @@ const getListings = async (
   try {
     const now = new Date()
 
-    const query = dbConnection('listing').where((builder) => {
+    const listings = await dbConnection('listing').where((builder) => {
       if (published) {
         builder
           .where('Status', '=', ListingStatus.Active)
@@ -284,8 +284,6 @@ const getListings = async (
         builder.andWhere('WaitingListType', '=', rentalRule)
       }
     })
-
-    const listings = await query
 
     const transformedListings = listings.map(transformFromDbListing)
 

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -75,7 +75,10 @@ export const routes = (router: KoaRouter) => {
 
     if (!result.ok) {
       ctx.status = 500
-      ctx.body = { error: 'Unknown error', ...metadata }
+      ctx.body = {
+        error: 'An unknown error occured when gettings listings',
+        ...metadata,
+      }
       return
     }
 

--- a/src/services/lease-service/routes/listings.ts
+++ b/src/services/lease-service/routes/listings.ts
@@ -28,6 +28,64 @@ export const routes = (router: KoaRouter) => {
   /**
    * @swagger
    * /listings:
+   *   get:
+   *     summary: Get listings
+   *     tags:
+   *       - Lease service
+   *     description: Retrieves a list of listings.
+   *     parameters:
+   *       - in: query
+   *         name: published
+   *         required: false
+   *         schema:
+   *           type: boolean
+   *         description: true for published listings, false for unpublished listings.
+   *       - in: query
+   *         name: waitingListType
+   *         required: false
+   *         schema:
+   *           type: string
+   *         description: ie "Scored" or "NonScored".
+   *     responses:
+   *       '200':
+   *         description: Successful response with the requested list of listings.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('(.*)/listings', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+
+    const querySchema = z.object({
+      published: z
+        .enum(['true', 'false'])
+        .optional()
+        .transform((value) => value === 'true'),
+      rentalRule: z.enum(['Scored', 'NonScored']).optional(),
+    })
+    const query = querySchema.safeParse(ctx.query)
+
+    const result = await listingAdapter.getListings(
+      query.data?.published,
+      query.data?.rentalRule
+    )
+
+    if (!result.ok) {
+      ctx.status = 500
+      ctx.body = { error: 'Unknown error', ...metadata }
+      return
+    }
+
+    ctx.status = 200
+    ctx.body = { content: result.data, ...metadata }
+  })
+
+  /**
+   * @swagger
+   * /listings:
    *   post:
    *     summary: Create new listing
    *     description: Create a new listing.

--- a/src/services/lease-service/tests/adapters/listing-adapter/get-listings.test.ts
+++ b/src/services/lease-service/tests/adapters/listing-adapter/get-listings.test.ts
@@ -1,0 +1,126 @@
+import { ListingStatus } from 'onecore-types'
+
+import * as listingAdapter from '../../../adapters/listing-adapter'
+import * as factory from '../../factories'
+import { withContext } from '../../testUtils'
+
+describe(listingAdapter.getListings, () => {
+  it('should filter on published', () =>
+    withContext(async (ctx) => {
+      const today = new Date()
+      const oneDayAgo = new Date(today.getTime() - 24 * 60 * 60 * 1000)
+      const threeDaysFromNow = new Date(
+        today.getTime() + 3 * 24 * 60 * 60 * 1000
+      )
+      const fiveDaysFromNow = new Date(
+        today.getTime() + 5 * 24 * 60 * 60 * 1000
+      )
+
+      // matching publish dates and status
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          publishedFrom: oneDayAgo,
+          publishedTo: threeDaysFromNow,
+          status: ListingStatus.Active,
+        }),
+        ctx.db
+      )
+
+      //matching publish dates only
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          publishedFrom: oneDayAgo,
+          publishedTo: threeDaysFromNow,
+          status: ListingStatus.Closed,
+        }),
+        ctx.db
+      )
+
+      //matching status only
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          publishedFrom: threeDaysFromNow,
+          publishedTo: fiveDaysFromNow,
+          status: ListingStatus.Active,
+        }),
+        ctx.db
+      )
+
+      const result = await listingAdapter.getListings(true, undefined, ctx.db)
+
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0].rentalObjectCode).toEqual('1')
+      }
+    }))
+
+  it('should filter on rentalRule', () =>
+    withContext(async (ctx) => {
+      // Create listings
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          waitingListType: 'Scored',
+          status: ListingStatus.Active,
+        }),
+        ctx.db
+      )
+
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          waitingListType: 'NonScored',
+          status: ListingStatus.Active,
+        }),
+        ctx.db
+      )
+
+      const result = await listingAdapter.getListings(
+        undefined,
+        'Scored',
+        ctx.db
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(1)
+        expect(result.data[0].rentalObjectCode).toEqual('1')
+      }
+    }))
+
+  it('should return a list of listings', () =>
+    withContext(async (ctx) => {
+      // Create listings
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '1',
+          status: ListingStatus.Active,
+        }),
+        ctx.db
+      )
+
+      await listingAdapter.createListing(
+        factory.listing.build({
+          rentalObjectCode: '2',
+          status: ListingStatus.Closed,
+        }),
+        ctx.db
+      )
+
+      const result = await listingAdapter.getListings(
+        undefined,
+        undefined,
+        ctx.db
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.data).toHaveLength(2)
+        expect(result.data.map((listing) => listing.rentalObjectCode)).toEqual(
+          expect.arrayContaining(['1', '2'])
+        )
+      }
+    }))
+})

--- a/src/services/lease-service/tests/routes/listings.test.ts
+++ b/src/services/lease-service/tests/routes/listings.test.ts
@@ -68,6 +68,91 @@ describe('GET /listing/:listingId/applicants/details', () => {
   })
 })
 
+describe('GET /listings', () => {
+  it('responds with 200 and listings', async () => {
+    jest.spyOn(listingAdapter, 'getListings').mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(3),
+    })
+
+    const res = await request(app.callback()).get('/listings')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(Number) }),
+      ]),
+    })
+  })
+
+  it('responds with 200 and listings with filter for published', async () => {
+    jest.spyOn(listingAdapter, 'getListings').mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(2),
+    })
+
+    const res = await request(app.callback()).get('/listings?published=true')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(Number) }),
+      ]),
+    })
+  })
+
+  it('responds with 200 and listings with filter for rentalRule', async () => {
+    jest.spyOn(listingAdapter, 'getListings').mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(1),
+    })
+
+    const res = await request(app.callback()).get('/listings?rentalRule=Scored')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(Number) }),
+      ]),
+    })
+  })
+
+  it('responds with 500 on unknown error', async () => {
+    jest.spyOn(listingAdapter, 'getListings').mockResolvedValueOnce({
+      ok: false,
+      err: 'unknown',
+    })
+
+    const res = await request(app.callback()).get('/listings')
+    expect(res.status).toBe(500)
+  })
+
+  it('responds with 200 and empty array if no listings found', async () => {
+    jest.spyOn(listingAdapter, 'getListings').mockResolvedValueOnce({
+      ok: true,
+      data: [],
+    })
+
+    const res = await request(app.callback()).get('/listings')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ content: [] })
+  })
+
+  it('responds with 200 and listings with filter for rentalRule and published', async () => {
+    jest.spyOn(listingAdapter, 'getListings').mockResolvedValueOnce({
+      ok: true,
+      data: factory.listing.buildList(2),
+    })
+
+    const res = await request(app.callback()).get(
+      '/listings?published=true&rentalRule=NonScored'
+    )
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      content: expect.arrayContaining([
+        expect.objectContaining({ id: expect.any(Number) }),
+      ]),
+    })
+  })
+})
+
 describe('GET /listings-with-applicants', () => {
   const getListingsWithApplicantsSpy = jest.spyOn(
     listingAdapter,


### PR DESCRIPTION
Leasing should provide an endpoint to get listings with options for published and rental rule (Scored/NonScored)

- [x] New endpoint /listings
- [x] New adapter function to get listings from the leasing database
- [x] Error handling & logging