### PR TITLE
Feature/uth 239 comment log for listings

### DIFF
--- a/migrations/20250523145209_create-comments-table.js
+++ b/migrations/20250523145209_create-comments-table.js
@@ -1,0 +1,37 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.transaction(async (trx) => {
+
+  await trx.raw(`
+  CREATE TABLE comment (
+    id int NOT NULL PRIMARY KEY IDENTITY(1,1),
+    targetType nvarchar(30) NOT NULL,
+    targetId int NOT NULL,
+    authorId nvarchar(100) NOT NULL,
+    authorName nvarchar(50) NOT NULL,
+    type nvarchar(8) NOT NULL CHECK (type IN ('COMMENT', 'WARNING', 'STOP')),
+    comment nvarchar(max) NOT NULL,
+    createdAt datetimeoffset NOT NULL DEFAULT SYSDATETIMEOFFSET()
+  );
+
+  CREATE INDEX idx_thread_id
+  ON comment (targetType, targetId);
+`)
+  })
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.transaction(async (trx) => {
+
+  await trx.raw(`
+    DROP TABLE comment;
+`)
+  })
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "koa-pino-logger": "^4.0.0",
         "koa2-swagger-ui": "^5.10.0",
         "mssql": "^11.0.1",
-        "onecore-types": "^3.7.1",
+        "onecore-types": "^3.11.0",
         "onecore-utilities": "^1.1.0",
         "personnummer": "^3.2.1",
         "pino": "^9.1.0",
@@ -7561,9 +7561,9 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.9.0.tgz",
-      "integrity": "sha512-qpE4ZE7m5Z9ymMW1zdlcRT5hmEtK8LLcDAlCSEaLzuz0bzU4I44NO3lwr8UiCUhJbPJywbb6/JV2zNM87zyp4A==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.11.0.tgz",
+      "integrity": "sha512-7oS+nmCei4xwbwTvTIOnXX0GjDFScFItD+TmJUFxCxszeWkwmuiAaPHup+oqNB2GoAv0LvfVU5PkVKUE4NpDaA==",
       "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "koa-pino-logger": "^4.0.0",
     "koa2-swagger-ui": "^5.10.0",
     "mssql": "^11.0.1",
-    "onecore-types": "^3.7.1",
+    "onecore-types": "^3.11.0",
     "onecore-utilities": "^1.1.0",
     "personnummer": "^3.2.1",
     "pino": "^9.1.0",

--- a/src/services/lease-service/adapters/comment-adapter.ts
+++ b/src/services/lease-service/adapters/comment-adapter.ts
@@ -1,0 +1,91 @@
+import { Comment, CommentThread, CommentThreadId } from 'onecore-types'
+import { DbComment } from './types'
+import { leasing } from 'onecore-types'
+import z from 'zod'
+
+import { db } from './db'
+
+const getCommentThreadById = async (
+  threadId: CommentThreadId,
+  dbConnection = db
+): Promise<CommentThread | undefined> => {
+  const comments = await dbConnection
+    .from('comment AS c')
+    .select<Array<DbComment>>(
+      'c.id AS Id',
+      'c.createdAt AS CreatedAt',
+      'c.type AS Type',
+      'c.authorId AS AuthorId',
+      'c.authorName AS AuthorName',
+      'c.comment AS Comment'
+    )
+    .where({
+      TargetType: threadId.targetType,
+      TargetId: threadId.targetId,
+    })
+    .orderBy('CreatedAt', 'desc')
+
+  return {
+    id: threadId,
+    comments: comments.map((c: DbComment) => {
+      return {
+        id: c.Id,
+        authorName: c.AuthorName,
+        authorId: c.AuthorId,
+        type: c.Type,
+        comment: c.Comment,
+        createdAt: c.CreatedAt,
+      }
+    }),
+  }
+}
+
+type AddCommentRequest = z.infer<
+  typeof leasing.v1.AddCommentRequestParamsSchema
+>
+
+const addComment = async (
+  threadId: CommentThreadId,
+  comment: AddCommentRequest,
+  dbConnection = db
+): Promise<Comment | undefined> => {
+  const [inserted] = await dbConnection
+    .table('comment')
+    .insert({
+      TargetType: threadId.targetType,
+      TargetId: threadId.targetId,
+      AuthorName: comment.authorName,
+      AuthorId: comment.authorId,
+      Type: comment.type,
+      Comment: comment.comment,
+    })
+    .returning('*')
+
+  return {
+    id: inserted.id,
+    authorName: inserted.authorName,
+    authorId: inserted.authorId,
+    type: inserted.type,
+    comment: inserted.comment,
+    createdAt: inserted.createdAt,
+  }
+}
+
+const removeComment = async (
+  threadId: CommentThreadId,
+  commentId: number,
+  dbConnection = db
+): Promise<void | undefined> => {
+  await dbConnection
+    .table('comment')
+    .where({
+      Id: commentId,
+      TargetType: threadId.targetType,
+      TargetId: threadId.targetId,
+    })
+    .delete()
+
+  return
+}
+
+export default { getCommentThreadById, addComment, removeComment }

--- a/src/services/lease-service/adapters/types.ts
+++ b/src/services/lease-service/adapters/types.ts
@@ -78,4 +78,15 @@ export type DbListing = {
   WaitingListType: string | null
 }
 
+export type DbComment = {
+  Id: number
+  TargetType: string
+  TargetId: number
+  AuthorName: string
+  AuthorId: string
+  CreatedAt: Date
+  Type: 'COMMENT' | 'WARNING' | 'STOP'
+  Comment: string
+}
+
 export type AdapterResult<T, E> = { ok: true; data: T } | { ok: false; err: E }

--- a/src/services/lease-service/index.ts
+++ b/src/services/lease-service/index.ts
@@ -1,5 +1,6 @@
 import KoaRouter from '@koa/router'
 import { routes as offerRoutes } from './routes/offers'
+import { routes as commentRoutes } from './routes/comments'
 import { routes as contactRoutes } from './routes/contacts'
 import { routes as invoiceRoutes } from './routes/invoices'
 import { routes as leaseRoutes } from './routes/leases'
@@ -9,6 +10,7 @@ import { routes as applicantsRoutes } from './routes/applicants'
 export const routes = (router: KoaRouter) => {
   applicantsRoutes(router)
   offerRoutes(router)
+  commentRoutes(router)
   contactRoutes(router)
   invoiceRoutes(router)
   leaseRoutes(router)

--- a/src/services/lease-service/routes/comments.ts
+++ b/src/services/lease-service/routes/comments.ts
@@ -1,0 +1,207 @@
+import KoaRouter from '@koa/router'
+import { generateRouteMetadata } from 'onecore-utilities'
+import commentAdapter from '../adapters/comment-adapter'
+import { leasing } from 'onecore-types'
+import z from 'zod'
+
+/**
+ * @swagger
+ * tags:
+ *   - name: Comments
+ *     description: Endpoints related to operations regarding comments on leasing objects.
+ */
+export const routes = (router: KoaRouter) => {
+  /**
+   * @swagger
+   * /comments/{targetType}/thread/{targetId}:
+   *   get:
+   *     summary: Get comment thread for an object
+   *     description: |
+   *       Fetch the entire comment thread for a specific object,
+   *       identified by the logical threadId of targetType/targetId.
+   *       All valid threadIds implicitly have a valid comment thread
+   *       resource even if no comments exists, in which case an empty
+   *       thread will be returned rather than 404 Not Found.
+   *     tags: [Comment]
+   *     parameters:
+   *       - in: path
+   *         name: targetType
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: |
+   *           The object type that the comment thread belongs to.
+   *       - in: path
+   *         name: targetId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: |
+   *           The object id that the comment thread belongs to.
+   *     responses:
+   *       200:
+   *         description: Comment thread object
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   description: The comment thread
+   *       500:
+   *         description: Internal server error
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('(.*)/comments/:targetType/thread/:targetId', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    const threadId = {
+      targetType: ctx.params.targetType,
+      targetId: Number(ctx.params.targetId),
+    }
+
+    const thread = await commentAdapter.getCommentThreadById(threadId)
+    if (thread == undefined) {
+      ctx.status = 200
+      ctx.body = { content: { id: threadId, comments: [] }, ...metadata }
+      return
+    }
+
+    ctx.body = { content: thread, ...metadata }
+  })
+
+  type AddCommentRequest = z.infer<
+    typeof leasing.v1.AddCommentRequestParamsSchema
+  >
+
+  /**
+   * @swagger
+   * /comments/{targetType}/thread/{targetId}:
+   *   get:
+   *     summary: Add a Comment to a CommentThread
+   *     description: |
+   *       Add a new comment to the comment thread for a specific object,
+   *       identified by the logical threadId of targetType/targetId.
+   *       All valid threadIds implicitly have a valid comment thread
+   *       resource even if no comments exists, which means that adding
+   *       a comment to a physically non-existing thread implicitly creates
+   *       it.
+   *     tags: [Comment]
+   *     parameters:
+   *       - in: path
+   *         name: targetType
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: |
+   *           The object type that the comment thread belongs to.
+   *       - in: path
+   *         name: targetId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: |
+   *           The object id that the comment thread belongs to.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *          application/json:
+   *             schema:
+   *               type: object
+   *     responses:
+   *       201:
+   *         description: The comment was successfully created
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   description: The created comment
+   *       500:
+   *         description: Internal server error
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.post('(.*)/comments/:targetType/thread/:targetId', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    const threadId = {
+      targetType: ctx.params.targetType,
+      targetId: Number(ctx.params.targetId),
+    }
+    const comment = <AddCommentRequest>ctx.request.body
+
+    const result = await commentAdapter.addComment(threadId, comment)
+
+    ctx.status = 201
+    ctx.body = { content: result, ...metadata }
+  })
+
+  /**
+   * @swagger
+   * /comments/{targetType}/thread/{targetId}/{commentId}:
+   *   get:
+   *     summary: Add a Comment to a CommentThread
+   *     description: |
+   *       Delete a comment from a comment thread.
+   *     tags: [Comment]
+   *     parameters:
+   *       - in: path
+   *         name: targetType
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: |
+   *           The object type that the comment thread belongs to.
+   *       - in: path
+   *         name: targetId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: |
+   *           The object id that the comment thread belongs to.
+   *       - in: path
+   *         name: commentId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: |
+   *           The unique ID of the comment to delete.
+   *     responses:
+   *       201:
+   *         description: The comment was successfully created
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   description: The created comment
+   *       500:
+   *         description: Internal server error
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.delete(
+    '(.*)/comments/:targetType/thread/:targetId/:commentId',
+    async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+
+      const { targetType, targetId, commentId } = ctx.params
+      const threadId = { targetType, targetId: Number(targetId) }
+
+      try {
+        await commentAdapter.removeComment(threadId, Number(commentId))
+
+        ctx.status = 200
+        ctx.body = { content: null, ...metadata }
+      } catch (e) {
+        ctx.status = 500
+        ctx.body = { error: 'unknown', ...metadata }
+      }
+    }
+  )
+}

--- a/src/services/lease-service/routes/comments.ts
+++ b/src/services/lease-service/routes/comments.ts
@@ -2,7 +2,6 @@ import KoaRouter from '@koa/router'
 import { generateRouteMetadata } from 'onecore-utilities'
 import commentAdapter from '../adapters/comment-adapter'
 import { leasing } from 'onecore-types'
-import z from 'zod'
 
 /**
  * @swagger


### PR DESCRIPTION
### WHAT

It began with a whisper. Somewhere deep within the very core-core of onecore-core, a lonely linted-away semicolon cried out for justice, just within earshot of an abominable trailing comma. This pull request is the culmination of a journey that began when I accidentally stared into the void of an unhandled promise and the void stared back.

I have refactored the temporal architecture to support quantum branching, so now each API call spawns an alternate timeline. I also rewired our database layer to respond emotionally to SQL queries.

I used my deep knowledge about the deep learning of things to teach the router to feel actual guilt when responding with a 404, and the middleware stack has been rebalanced to adhere to the Fibonacci sequence, which should reduce latency by about 0.0000002% but also just won't be bother to respond at all most of the time.

To ensure system stability, I performed a blood ritual over the leasing-service column of the app, appeased the machine spirits, and replaced all deprecated dependencies with slightly more sarcastic ones - praise Omnissiah!. All code has been blessed with a rubber duck and cursed with a TODO comment that reads simply: "Good luck. You'll need it".

I then experienced a moment of doubt and reverted the whole thing.

### BONUS

Oh, yeah, and I added routes, db layer and migrations for the comments feature. Those are still in there. 