### PR TITLE
Use service connection pools for health checks + db pool configuration

### DIFF
--- a/src/services/health-service/index.ts
+++ b/src/services/health-service/index.ts
@@ -3,7 +3,8 @@ import { SystemHealth, ListingStatus } from 'onecore-types'
 import config from '../../common/config'
 import { healthCheck as xpandSoapApiHealthCheck } from '../lease-service/adapters/xpand/xpand-soap-adapter'
 import { healthCheck as creditSafeHealthCheck } from '../creditsafe/adapters/creditsafe-adapter'
-import knex from 'knex'
+import { db as leasingDb } from '../lease-service/adapters/db'
+import { xpandDb } from '../lease-service/adapters/xpand/xpandDb'
 
 const healthChecks: Map<string, SystemHealth> = new Map()
 
@@ -69,12 +70,7 @@ const subsystems = [
         config.health.leasingDatabase.systemName,
         config.health.leasingDatabase.minimumMinutesBetweenRequests,
         async () => {
-          const db = knex({
-            client: 'mssql',
-            connection: config.leasingDatabase,
-          })
-
-          await db.table('listing').limit(1)
+          await leasingDb.table('listing').limit(1)
         }
       )
     },
@@ -85,12 +81,7 @@ const subsystems = [
         config.health.xpandDatabase.systemName,
         config.health.xpandDatabase.minimumMinutesBetweenRequests,
         async () => {
-          const db = knex({
-            client: 'mssql',
-            connection: config.xpandDatabase,
-          })
-
-          await db.table('cmctc').limit(1)
+          await xpandDb.table('cmctc').limit(1)
         }
       )
     },
@@ -101,11 +92,7 @@ const subsystems = [
         config.health.expiredListingsScript.systemName,
         config.health.expiredListingsScript.minimumMinutesBetweenRequests,
         async () => {
-          const db = knex({
-            client: 'mssql',
-            connection: config.leasingDatabase,
-          })
-          const expiredActiveListings = await db('listing')
+          const expiredActiveListings = await leasingDb('listing')
             .where('PublishedTo', '<', new Date(Date.now() - 86400000))
             .andWhere('Status', ListingStatus.Active)
 
@@ -224,5 +211,76 @@ export const routes = (router: KoaRouter) => {
     }
 
     ctx.body = health
+  })
+
+  const CONNECTIONS = [
+    {
+      name: 'leasing',
+      pool: leasingDb,
+    },
+    {
+      name: 'xpand',
+      pool: xpandDb,
+    },
+  ]
+
+  /**
+   * @openapi
+   * /health/db:
+   *   get:
+   *     summary: Database connection pool metrics
+   *     tags: [Health]
+   *     responses:
+   *       '200':
+   *         description: Connection pool stats per configured DB connection.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 connectionPools:
+   *                   type: integer
+   *                   minimum: 0
+   *                 metrics:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       name:
+   *                         type: string
+   *                       pool:
+   *                         type: object
+   *                         properties:
+   *                           used: { type: integer, minimum: 0 }
+   *                           free: { type: integer, minimum: 0 }
+   *                           pendingCreates: { type: integer, minimum: 0 }
+   *                           pendingAcquires: { type: integer, minimum: 0 }
+   *             examples:
+   *               sample:
+   *                 value:
+   *                   connectionPools: 2
+   *                   metrics:
+   *                     - name: "primary"
+   *                       pool: { used: 3, free: 5, pendingCreates: 0, pendingAcquires: 1 }
+   *                     - name: "reporting"
+   *                       pool: { used: 0, free: 8, pendingCreates: 0, pendingAcquires: 0 }
+   */
+  router.get('(.*)/health/db', async (ctx) => {
+    ctx.body = {
+      connectionPools: CONNECTIONS.length,
+      metrics: CONNECTIONS.map((conn) => {
+        const pool = conn.pool.client.pool
+
+        return {
+          name: conn.name,
+          pool: {
+            used: pool.numUsed(),
+            free: pool.numFree(),
+            pendingCreates: pool.numPendingCreates(),
+            pendingAcquires: pool.numPendingAcquires(),
+          },
+        }
+      }),
+    }
   })
 }

--- a/src/services/lease-service/adapters/db.ts
+++ b/src/services/lease-service/adapters/db.ts
@@ -6,6 +6,12 @@ export const createDbClient = () =>
   knex({
     client: 'mssql',
     connection: Config.leasingDatabase,
+    pool: {
+      min: 2,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      destroyTimeoutMillis: 5000,
+    },
   })
 
 export const db = createDbClient()

--- a/src/services/lease-service/adapters/xpand/xpandDb.ts
+++ b/src/services/lease-service/adapters/xpand/xpandDb.ts
@@ -6,6 +6,12 @@ export const createXpandDbClient = () =>
   knex({
     client: 'mssql',
     connection: Config.xpandDatabase,
+    pool: {
+      min: 2,
+      max: 20,
+      idleTimeoutMillis: 30000,
+      destroyTimeoutMillis: 5000,
+    },
   })
 
 export const xpandDb = createXpandDbClient()


### PR DESCRIPTION
### What
- Use knex instances/db pools configured and used by the service in health service
- Adds some basic sanity-check db pool configuration

### Why
- For The Glory of THE EMPIRE